### PR TITLE
Harden supply validation and transaction encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Irium Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bootstrap/anchors.json
+++ b/bootstrap/anchors.json
@@ -1,0 +1,19 @@
+{
+  "signers": [
+    "irm1qfndr000000000000000000000000000000000",
+    "irm1qguardian00000000000000000000000000000"
+  ],
+  "anchors": [
+    {
+      "height": 0,
+      "block_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "timestamp": 1735689600,
+      "signatures": [
+        {
+          "signer": "founder",
+          "signature": "3045022100b7ff2f1381cd38f75bd527ae919becd10b6f11329ab3aee944b067ed1390f0c60220389d3a956a74d41a760e6a5cf175ac869d8af462ec2c84939b4da02e8fb08035"
+        }
+      ]
+    }
+  ]
+}

--- a/bootstrap/seedlist.runtime
+++ b/bootstrap/seedlist.runtime
@@ -1,0 +1,1 @@
+# Runtime seedlist refreshed 2024-01-01T00:00:00Z

--- a/bootstrap/seedlist.txt
+++ b/bootstrap/seedlist.txt
@@ -1,0 +1,4 @@
+# IPv4 and IPv6 multiaddresses for bootstrap
+/ipv4/203.0.113.10/tcp/38291
+/ipv4/198.51.100.27/tcp/38291
+/ipv6/2001:db8::14/tcp/38291

--- a/bootstrap/seedlist.txt.sig
+++ b/bootstrap/seedlist.txt.sig
@@ -1,0 +1,9 @@
+{
+  "hash": "61212070081c48303c3f3fddff23edf553e0927cb5a06b2d8b5c0883f49aa325",
+  "signatures": [
+    {
+      "signer": "founder",
+      "signature": "3045022100f8b83e88af2e729e96c1c55bb45cf227d127cd64d5f3739a105c73156ad7c72c02204cb692da3f3ed90cac84a9b2aee11f66b5786446f571f97933649ee35e7ac78b"
+    }
+  ]
+}

--- a/configs/genesis.json
+++ b/configs/genesis.json
@@ -1,0 +1,13 @@
+{
+  "network": "mainnet",
+  "timestamp": 1735689600,
+  "bits": "1d00ffff",
+  "nonce": 2083236893,
+  "allocations": [
+    {
+      "label": "founder_vesting_3y",
+      "amount_sats": 350000000000000,
+      "script_pubkey": "03f06702b17576a9144f3cf4b44d0132891613be16caf253162072281888ac"
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+# Irium Mainnet Architecture
+
+## Consensus
+
+* **Algorithm:** Proof-of-Work using SHA-256d.
+* **Target block time:** 600 seconds.
+* **Difficulty retarget:** every 2016 blocks, bounded between 4x and 0.25x adjustments.
+* **Monetary policy:** 3,500,000 IRM minted in genesis, 96,500,000 IRM mined over 1,930,000 blocks, then fee-only rewards.
+* **Coinbase maturity:** 100 blocks.
+
+The reference `ChainState` verifies that every block extends the active tip, recomputes merkle roots, enforces SHA-256d proof-of-work targets, and rejects coinbase payouts that exceed the permitted subsidy plus collected fees while keeping an in-memory UTXO set for subsequent transaction validation. It now also enforces canonical output encodings and tracks the cumulative subsidy so the chain can never issue more than the fixed 100 million IRM supply.
+
+## Genesis Distribution
+
+The genesis block coinbase transaction mints only the 3,500,000 IRM founder allocation. No other addresses receive genesis funds
+—the remaining 96,500,000 IRM is unlocked exclusively through proof-of-work mining.
+
+* **Founder vesting:** 3,500,000 IRM locked via `OP_CHECKLOCKTIMEVERIFY` for three years (expressed in block height).
+* **Mining supply:** 96,500,000 IRM reserved for 50 IRM subsidies on blocks 1–1,930,000; after that point the network becomes fee only.
+
+The distribution is declared in `configs/genesis.json` with explicit scriptPubKeys so anyone can validate the CLTV commitments.
+
+## Bootstrap Strategy
+
+Irium launches without DNS seeds. Nodes bootstrap by downloading signed `seedlist.txt` and `anchors.json` files. The shell helper `scripts/irium-zero.sh` fetches the latest artifacts, verifies their secp256k1 signatures, and exports the raw multiaddresses. Clients then connect directly to the listed peers and merge them with the runtime cache maintained at `bootstrap/seedlist.runtime`.
+
+### Self-healing Discovery
+
+Nodes gossip uptime proofs for peers via libp2p. Each node stores a rolling cache of verified peers (address, services, proof). When a new node joins it requests these caches, enabling peer discovery even if the original seed list disappears. The Python `PeerDirectory` utility persists these observations to `state/peers.json` and refreshes `seedlist.runtime` so tooling can immediately benefit from the expanding peer surface.
+
+### Anchor File Consensus
+
+`anchors.json` contains rolling header commitments. Each entry hashes the height, block hash, and timestamp into a deterministic digest that is signed by designated bootstrap keys via secp256k1. During initial sync a node cross-validates downloaded headers against these anchors to limit eclipse and long-range attacks.
+
+## Relay Reward Commitments
+
+Miners can voluntarily dedicate a portion of transaction fees to their upstream relay peers. The reference `irium.miner.Miner` encodes each `RelayCommitment` as a standard P2PKH output funded from collected fees and, optionally, an `OP_RETURN` memo tagged with `relay:` metadata for auditability. The miner verifies that the aggregated commitment amounts never exceed the fee pool before finalizing the coinbase.
+
+### Block Assembly Pipeline
+
+The miner consumes `TxCandidate` objects—each containing a transaction, fee, and weight—and sorts them by satoshi-per-weight to maximize yield within the 4,000,000 weight limit. It then builds the block header using the latest chain tip, crafts a BIP34-style coinbase script with an incrementing extra nonce, and refreshes the merkle root after every modification. When the 32-bit nonce space is exhausted the extra nonce is bumped and the coinbase is regenerated automatically. Runtime metrics (attempt count, elapsed time, accumulated fees) are exported via `MiningStats` so production deployments can coordinate hardware sweeps while relying on the shared block template logic.
+
+## P2P Handshake Hardening
+
+Handshake flow uses ephemeral X25519 keys. Each side signs the handshake transcript with its long-term node key and includes a lightweight Proof-of-Uptime token (hashcash-like). Nodes refusing to present valid proofs are deprioritized.
+
+## Light Client Support
+
+The `irium.wallet` package now bundles deterministic key management, UTXO tracking, and fully signed P2PKH transaction assembly. These primitives are shared between full nodes and SPV clients, which can verify anchors and NiPoPoW proofs while relying on the same wallet core. Future work will layer networked SPV synchronization on top of the shipped wallet foundation.
+
+## On-chain Metadata Commitments
+
+Blocks may include a single coinbase `OP_RETURN` output referencing off-chain payloads via a SHA-256 multihash. This keeps the chain lean while notarizing documents such as updated seedlists or governance announcements.

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,0 +1,116 @@
+# Irium: DNS-Free Proof-of-Work Mainnet
+
+## Abstract
+
+Irium is a purpose-built proof-of-work blockchain designed to maximize network independence and long-term survivability. The protocol eliminates reliance on DNS infrastructure, enforces transparent founder vesting via on-chain timelocks, incentivizes transaction relay quality without inflation, and prioritizes light client usability from genesis. This whitepaper outlines the core design principles, system architecture, monetary policy, and roadmap for the IRM asset and its supporting network.
+
+## 1. Introduction
+
+Most established proof-of-work networks inherit architectural assumptions from Bitcoin, including DNS-based bootstrapping, addrman-driven peer discovery, and an absence of protocol-level incentives for fast relay. Irium rethinks these components to produce a mainnet that can launch and sustain itself even if all founding infrastructure disappears. The project ships with no test or demo networks; development centers solely on a production-ready mainnet.
+
+### 1.1 Goals
+- Ensure permanent bootstrap viability without DNS dependencies or trusted third-party domains.
+- Deliver transparent, consensus-enforced founder vesting with irreversible timelocks.
+- Provide miners and relay nodes with optional fee-sharing incentives that reward high-quality propagation.
+- Harden the peer discovery layer against Sybil attacks and botnet saturation.
+- Enable NiPoPoW-ready light clients and SPV tooling from the network’s first block.
+- Maintain a lean on-chain footprint while enabling notarization of off-chain metadata.
+
+## 2. System Architecture Overview
+
+Irium separates responsibilities into modular subsystems that interoperate through explicit interfaces:
+
+1. **Consensus Core** – Handles block production, validation, and difficulty retargeting using SHA-256d proof-of-work. The reference implementation is authored in Python to remain auditable and succinct.
+2. **Genesis Framework** – A deterministic JSON configuration (`configs/genesis.json`) together with a builder script constructs the genesis block and CLTV-locked founder output while leaving the mining supply unallocated until proof-of-work issuance.
+3. **Bootstrap Layer** – Uses signed `seedlist.txt` and `anchors.json` artifacts, distributed through multiple channels (GitHub releases, IPFS, torrents). Nodes bootstrap exclusively from these signed resources.
+4. **Peer-to-Peer Network** – Built atop libp2p gossip protocols with self-healing peer state, uptime proofs, and Sybil-resistant handshakes.
+5. **Client Ecosystem** – Provides primitives for full nodes and SPV wallets, enabling users to verify transactions via NiPoPoW proofs and anchor checkpoints.
+
+## 3. Consensus Mechanics
+
+### 3.1 Proof-of-Work
+- Algorithm: SHA-256d (double SHA-256 hashing of block headers).
+- Target Block Time: 600 seconds.
+- Difficulty Retarget: Every 2016 blocks using a bounded adjustment to avoid oscillations.
+- Coinbase Maturity: 100 blocks to mitigate short-range reorg exploitation.
+
+The `ChainState` reference implementation recalculates merkle roots, enforces that each block header links to the current tip, validates the SHA-256d target, and refuses coinbase payouts that exceed the allowed subsidy plus accrued fees. While accepting blocks it maintains an in-memory UTXO set so subsequent transactions are checked for double spends and value conservation, additionally rejecting outputs whose encodings overflow consensus limits and accounting for cumulative subsidy so issuance can never surpass the 100 million IRM cap.
+
+### 3.2 Monetary Policy
+- Maximum Supply: 100,000,000 IRM.
+- Genesis Mint: 3,500,000 IRM is created in the block 0 coinbase transaction and timelocked for three years.
+- Mining Emission: Blocks 1 through 1,930,000 award a fixed 50 IRM subsidy (5,000,000,000 satoshis) to miners; after this window the subsidy drops to zero and rewards become fee-only.
+- Supply Invariance: Consensus validation rejects coinbase payouts that exceed the scheduled subsidy plus collected fees, preventing inflation or effective burning via negative fee accounting, while tracking minted subsidy totals against the immutable 100 million IRM ceiling.
+
+### 3.3 Genesis Distribution
+- Total Founder Allocation: 3,500,000 IRM held in a single output.
+- Timelock: CLTV-enforced at the block height corresponding to three years of blocks from genesis.
+- Mining Supply: 96,500,000 IRM left unallocated at genesis and released solely through proof-of-work subsidies.
+
+The genesis layout is encoded in human-readable JSON and reproducible with deterministic tooling to support third-party audits.
+
+## 4. Bootstrapping Without DNS
+
+Traditional blockchain clients query DNS seeds to discover peers, creating a single point of failure. Irium replaces this mechanism with cryptographically authenticated artifacts:
+
+- **seedlist.txt** – Contains IPv4/IPv6 multiaddresses along with libp2p peer IDs. A detached secp256k1 signature ensures authenticity.
+- **seedlist.runtime** – A node-maintained cache that automatically records newly observed peers. Tooling merges the signed list with this runtime cache to remain connected as the network evolves.
+- **anchors.json** – Publishes a rolling set of block header checkpoints. Each record hashes the height, block hash, and timestamp and is signed by designated anchor signers via secp256k1. Clients cross-check header sync against these anchors to detect potential eclipse attacks.
+- **irium-zero.sh** – Automates signature verification, seed extraction, and node initialization. Users can run the script offline after mirroring the artifacts.
+
+Multiple distribution channels (GitHub, IPFS, torrents) provide redundancy. Because bootstrap never depends on DNS, the network can persist even if all official domains vanish.
+
+## 5. Peer Networking and Security
+
+### 5.1 Self-Healing Discovery
+Peers exchange uptime attestations over libp2p gossip. Each attestation references other peers, allowing the network to “remember” reliable participants even if the initial seedlist disappears. Nodes adjust peer scoring based on observed performance, enabling organic evolution of the peer set. The reference `PeerDirectory` persists these observations to disk and refreshes `seedlist.runtime`, giving fresh nodes immediate access to recently verified peers without touching DNS.
+
+### 5.2 Sybil-Resistant Handshakes
+Every handshake uses ephemeral key pairs that sign a proof-of-uptime token (a small proof-of-work or time-bound capability). Peers verify these tokens before admitting connections, discouraging large-scale Sybil attacks and botnet flooding.
+
+### 5.3 Relay Reward Commitments
+Miners may include optional relay rewards in their coinbase transactions. Each reward is expressed as a standard P2PKH output that directs a portion of the block’s fee pool to the designated relay peer, ensuring payout enforcement by consensus without inflating supply. An accompanying `OP_RETURN` memo tagged with `relay:` data can be emitted for auditability, allowing operators to prove their relay contributions via merkle proofs while keeping fee accounting transparent.
+
+### 5.4 Anchor-File Consensus
+`anchors.json` acts as an audit layer that complements the canonical blockchain history. Anchor signers publish checkpoints containing block hashes, heights, and aggregated signatures. Clients validate downloaded headers against these checkpoints to ensure they follow a chain vetted by multiple independent signers, reducing the risk of eclipse or long-range attacks.
+
+### 5.5 Metadata Commitments
+Coinbase transactions may embed hash pointers referencing documentation, open-source mirrors, regulatory filings, or updated seedlists. Because only hash commitments are stored on-chain, the ledger avoids unbounded growth while preserving an immutable link to critical off-chain information.
+
+## 6. Light Client Strategy
+
+Irium is light-client-first. The reference Python package now exposes:
+- Header validation routines compatible with SPV wallets.
+- Merkle proof verification utilities.
+- Anchor checkpoint validation functions.
+- A deterministic hot wallet that manages keys, UTXOs, and RFC6979-signed P2PKH transactions.
+
+These tools support NiPoPoW techniques where clients verify short proofs of work instead of downloading the full chain. By combining NiPoPoWs with anchor checkpoints and the shared wallet core, light clients can securely operate even in adversarial network environments while remaining interoperable with full-node tooling.
+
+### 5.6 Reference Mining Loop
+The open-source `irium.miner` module packages block assembly logic: transaction selection by fee density, BIP34-compliant coinbase creation with automatic extra-nonce cycling, relay reward validation, and nonce iteration. It emits `MiningStats` so miners coordinating heterogeneous hardware can track attempt counts and wall-clock mining time while sharing a deterministic block template generator.
+
+## 7. Implementation Status
+
+- **Complete:** Genesis specification, deterministic builder, proof-of-work primitives, block and transaction serialization, bootstrap verification tooling, peer directory with automatic seedlist maintenance, hot wallet integration, reference mining loop, protocol documentation.
+- **In Progress:** Production-ready libp2p networking layer, relay reward accounting integration, comprehensive wallet UX.
+- **Planned:** External security audits, formal specification of relay reward algorithms, integration of hardware wallet signing flows for CLTV outputs.
+
+## 8. Governance and Upgrade Path
+
+Irium favors rough consensus and public review over on-chain governance. Proposed consensus changes follow this pipeline:
+1. Draft improvement proposals referencing the whitepaper and architectural documentation.
+2. Prototype implementations in dedicated branches or repositories (never in mainnet by default).
+3. Conduct multi-stakeholder audits (miners, developers, service providers).
+4. Coordinate network upgrades via signed anchor announcements and miner signaling.
+
+## 9. Conclusion
+
+Irium delivers a mainnet-first blockchain architecture that prioritizes independence, verifiability, and user sovereignty. By removing DNS from bootstrap, enforcing founder vesting at the consensus layer, and launching with robust light client support, the project sets a new baseline for sustainable proof-of-work networks.
+
+## 10. References
+
+1. Satoshi Nakamoto, “Bitcoin: A Peer-to-Peer Electronic Cash System,” 2008.
+2. Aggelos Kiayias et al., “Non-Interactive Proofs of Proof-of-Work (NiPoPoWs),” 2017.
+3. libp2p Project, “libp2p Specification,” https://github.com/libp2p/specs.
+

--- a/irium/__init__.py
+++ b/irium/__init__.py
@@ -1,0 +1,19 @@
+"""Irium mainnet primitives."""
+
+from .chain import ChainParams, ChainState
+from .miner import Miner, MiningStats, RelayCommitment, TxCandidate
+from .network import PeerDirectory, SeedlistManager
+from .wallet import KeyPair, Wallet
+
+__all__ = [
+    "ChainParams",
+    "ChainState",
+    "PeerDirectory",
+    "SeedlistManager",
+    "KeyPair",
+    "Wallet",
+    "Miner",
+    "TxCandidate",
+    "RelayCommitment",
+    "MiningStats",
+]

--- a/irium/block.py
+++ b/irium/block.py
@@ -1,0 +1,77 @@
+"""Block primitives for the Irium blockchain."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import List
+
+from .pow import Target, header_hash
+from .tx import Transaction
+
+
+@dataclass
+class BlockHeader:
+    version: int
+    prev_hash: bytes
+    merkle_root: bytes
+    time: int
+    bits: int
+    nonce: int
+
+    def serialize(self) -> bytes:
+        return (
+            self.version.to_bytes(4, "little")
+            + self.prev_hash[::-1]
+            + self.merkle_root[::-1]
+            + self.time.to_bytes(4, "little")
+            + self.bits.to_bytes(4, "little")
+            + self.nonce.to_bytes(4, "little")
+        )
+
+    def hash(self) -> bytes:
+        return header_hash([self.serialize()])[::-1]
+
+    @property
+    def target(self) -> Target:
+        return Target(self.bits)
+
+
+@dataclass
+class Block:
+    header: BlockHeader
+    transactions: List[Transaction] = field(default_factory=list)
+
+    def merkle_root(self) -> bytes:
+        if not self.transactions:
+            return bytes.fromhex(
+                "0" * 64
+            )
+        leaves = [tx.txid()[::-1] for tx in self.transactions]
+        while len(leaves) > 1:
+            if len(leaves) % 2 == 1:
+                leaves.append(leaves[-1])
+            leaves = [header_hash([leaves[i], leaves[i + 1]]) for i in range(0, len(leaves), 2)]
+        return leaves[0]
+
+    def update_merkle_root(self) -> None:
+        self.header.merkle_root = self.merkle_root()[::-1]
+
+    def mine(self) -> None:
+        self.update_merkle_root()
+        target = self.header.target
+        nonce = 0
+        while True:
+            self.header.nonce = nonce
+            block_hash = self.header.hash()[::-1]
+            if int.from_bytes(block_hash, "big") <= target.to_target():
+                break
+            nonce += 1
+
+    @property
+    def size(self) -> int:
+        return len(self.header.serialize()) + sum(len(tx.serialize()) for tx in self.transactions)
+
+    @property
+    def weight(self) -> int:
+        return self.size * 4

--- a/irium/chain.py
+++ b/irium/chain.py
@@ -1,0 +1,197 @@
+"""Minimal blockchain state machine for Irium."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+from .block import Block, BlockHeader
+from .constants import (
+    BLOCK_TARGET_INTERVAL,
+    DIFFICULTY_RETARGET_INTERVAL,
+    MAX_MONEY,
+    SUBSIDY_SCHEDULE,
+)
+from .pow import Target
+from .tx import Transaction, TxOutput
+
+
+@dataclass
+class ChainParams:
+    genesis_block: Block
+    pow_limit: Target
+
+
+@dataclass
+class ChainState:
+    params: ChainParams
+    height: int = 0
+    chain: List[Block] = field(default_factory=list)
+    total_work: int = 0
+    utxos: Dict[Tuple[bytes, int], TxOutput] = field(default_factory=dict)
+    issued: int = 0
+
+    def __post_init__(self) -> None:
+        self._connect_genesis(self.params.genesis_block)
+
+    def expected_time(self, height: int) -> int:
+        return height * BLOCK_TARGET_INTERVAL
+
+    def target_for_height(self, height: int) -> Target:
+        if height == 0:
+            return self.params.genesis_block.header.target
+        last_block = self.chain[-1]
+        if height % DIFFICULTY_RETARGET_INTERVAL != 0 or height < DIFFICULTY_RETARGET_INTERVAL:
+            return last_block.header.target
+        prev = self.chain[-DIFFICULTY_RETARGET_INTERVAL]
+        actual_time = last_block.header.time - prev.header.time
+        expected_time = DIFFICULTY_RETARGET_INTERVAL * BLOCK_TARGET_INTERVAL
+        adjustment = max(min(actual_time / expected_time, 4), 0.25)
+        new_target_value = int(last_block.header.target.to_target() * adjustment)
+        return Target.from_target(new_target_value)
+
+    def connect_block(self, block: Block) -> None:
+        expected_height = self.height
+        previous = self.chain[-1] if self.chain else None
+        self._validate_block_header(block, expected_height, previous)
+        block_reward = SUBSIDY_SCHEDULE.block_reward(expected_height)
+        fees, coinbase_total, subsidy_created = self._validate_and_apply_transactions(
+            block,
+            block_reward,
+            enforce_reward=True,
+            max_subsidy=MAX_MONEY - self.issued,
+        )
+        new_supply = self.issued + subsidy_created
+        self.chain.append(block)
+        self.height += 1
+        self.total_work += int(0xFFFF_FFFF / block.header.target.to_target())
+        self.issued = new_supply
+
+    def _connect_genesis(self, block: Block) -> None:
+        if self.chain:
+            raise ValueError("Genesis block already connected")
+        self._validate_block_header(block, expected_height=0, previous=None)
+        fees, coinbase_total, subsidy_created = self._validate_and_apply_transactions(
+            block,
+            block_reward=0,
+            enforce_reward=False,
+            max_subsidy=MAX_MONEY,
+        )
+        self.chain.append(block)
+        self.height = 1
+        self.total_work = int(0xFFFF_FFFF / block.header.target.to_target())
+        self.issued = subsidy_created
+
+    def _validate_block_header(self, block: Block, height: int, previous: Block | None) -> None:
+        if previous is not None:
+            if block.header.prev_hash != previous.header.hash():
+                raise ValueError("Block does not extend the current tip")
+        elif block.header.prev_hash != b"\x00" * 32:
+            raise ValueError("Genesis block must reference null hash")
+
+        recalculated_root = block.merkle_root()[::-1]
+        if block.header.merkle_root != recalculated_root:
+            raise ValueError("Block merkle root mismatch")
+
+        header_hash = block.header.hash()[::-1]
+        target = self.target_for_height(height)
+        if int.from_bytes(header_hash, "big") > target.to_target():
+            raise ValueError("Block does not satisfy proof-of-work target")
+
+    def _validate_and_apply_transactions(
+        self,
+        block: Block,
+        block_reward: int,
+        *,
+        enforce_reward: bool,
+        max_subsidy: int | None = None,
+    ) -> Tuple[int, int, int]:
+        if not block.transactions:
+            raise ValueError("Block must include transactions")
+        coinbase = block.transactions[0]
+        if not _is_coinbase(coinbase):
+            raise ValueError("First transaction must be coinbase")
+        if not coinbase.outputs:
+            raise ValueError("Coinbase transaction must create outputs")
+
+        created: List[Tuple[bytes, int, TxOutput]] = []
+        fees = 0
+        seen_inputs: set[Tuple[bytes, int]] = set()
+
+        for tx in block.transactions[1:]:
+            if not tx.inputs:
+                raise ValueError("Transaction must have at least one input")
+            if not tx.outputs:
+                raise ValueError("Transaction must have at least one output")
+            input_total = 0
+            for txin in tx.inputs:
+                key = (txin.prev_txid, txin.prev_index)
+                if len(txin.prev_txid) != 32:
+                    raise ValueError("Transaction input has invalid txid length")
+                if not (0 <= txin.prev_index <= 0xFFFFFFFF):
+                    raise ValueError("Transaction input index out of range")
+                if key in seen_inputs:
+                    raise ValueError("Transaction input double spent within block")
+                utxo = self.utxos.get(key)
+                if utxo is None:
+                    raise ValueError("Referenced UTXO is missing")
+                seen_inputs.add(key)
+                input_total += utxo.value
+            output_total = 0
+            for output in tx.outputs:
+                _validate_output(output)
+                output_total += output.value
+            if input_total < output_total:
+                raise ValueError("Transaction spends more than available inputs")
+            fees += input_total - output_total
+            if fees < 0 or fees > MAX_MONEY:
+                raise ValueError("Fee accounting overflow")
+            txid = tx.txid()
+            for index, output in enumerate(tx.outputs):
+                created.append((txid, index, output))
+
+        coinbase_total = 0
+        for output in coinbase.outputs:
+            _validate_output(output)
+            coinbase_total += output.value
+            if coinbase_total > MAX_MONEY:
+                raise ValueError("Coinbase outputs overflow")
+        if enforce_reward and coinbase_total > block_reward + fees:
+            raise ValueError("Coinbase transaction exceeds allowed reward")
+
+        coinbase_txid = coinbase.txid()
+        for index, output in enumerate(coinbase.outputs):
+            created.append((coinbase_txid, index, output))
+
+        available_fees = min(fees, coinbase_total)
+        subsidy_created = coinbase_total - available_fees
+        if subsidy_created < 0:
+            subsidy_created = 0
+        if enforce_reward:
+            subsidy_created = min(block_reward, subsidy_created)
+        if max_subsidy is not None and subsidy_created > max_subsidy:
+            raise ValueError("Coinbase subsidy would exceed permitted supply")
+
+        for key in seen_inputs:
+            self.utxos.pop(key, None)
+        for txid, index, output in created:
+            self.utxos[(txid, index)] = output
+
+        return fees, coinbase_total, subsidy_created
+
+
+def _is_coinbase(tx: Transaction) -> bool:
+    if len(tx.inputs) != 1:
+        return False
+    coinbase_input = tx.inputs[0]
+    return (
+        coinbase_input.prev_txid == b"\x00" * 32
+        and coinbase_input.prev_index == 0xFFFFFFFF
+    )
+
+
+def _validate_output(output: TxOutput) -> None:
+    if not (0 <= output.value <= MAX_MONEY):
+        raise ValueError("Output value out of range")
+    if len(output.script_pubkey) > 0xFF:
+        raise ValueError("script_pubkey too large")

--- a/irium/constants.py
+++ b/irium/constants.py
@@ -1,0 +1,47 @@
+"""Network-wide constants for Irium mainnet."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Final
+
+
+@dataclasses.dataclass(frozen=True)
+class SubsidySchedule:
+    """Describes the block subsidy emission curve."""
+
+    initial_reward: int
+    mining_supply: int
+    coinbase_maturity: int
+
+    def block_reward(self, height: int) -> int:
+        """Return the block subsidy for a specific block height."""
+        if height < 0:
+            raise ValueError("Block height cannot be negative")
+        if self.initial_reward <= 0:
+            return 0
+        if height == 0:
+            return 0
+
+        full_reward_blocks, remainder = divmod(self.mining_supply, self.initial_reward)
+        if height <= full_reward_blocks:
+            return self.initial_reward
+        if remainder and height == full_reward_blocks + 1:
+            return remainder
+        return 0
+
+
+MAX_MONEY: Final[int] = 100_000_000 * 10**8  # satoshis equivalent
+BLOCK_TARGET_INTERVAL: Final[int] = 600  # seconds
+DIFFICULTY_RETARGET_INTERVAL: Final[int] = 2016  # blocks
+POW_ALGORITHM: Final[str] = "sha256d"
+GENESIS_TIMELOCKS: Final[tuple[int, ...]] = (3 * 365 * 24 * 60 * 60,)
+GENESIS_BLOCK_HEIGHT: Final[int] = 0
+GENESIS_TOTAL_VESTING: Final[int] = 3_500_000 * 10**8
+GENESIS_PUBLIC_SUPPLY: Final[int] = 96_500_000 * 10**8
+PUBKEY_ADDRESS_PREFIX: Final[int] = 0x39  # Base58 prefix for Irium P2PKH addresses
+SUBSIDY_SCHEDULE: Final[SubsidySchedule] = SubsidySchedule(
+    initial_reward=50 * 10**8,
+    mining_supply=GENESIS_PUBLIC_SUPPLY,
+    coinbase_maturity=100,
+)

--- a/irium/miner.py
+++ b/irium/miner.py
@@ -1,0 +1,272 @@
+"""Mining loop utilities for the Irium mainnet."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+from .block import Block, BlockHeader
+from .chain import ChainState
+from .constants import BLOCK_TARGET_INTERVAL, SUBSIDY_SCHEDULE
+from .tx import Transaction, TxInput, TxOutput
+from .wallet import Wallet, address_to_script
+
+_MAX_BLOCK_WEIGHT = 4_000_000  # Segwit-style weight limit analogue
+
+
+@dataclass(frozen=True)
+class TxCandidate:
+    """Transaction plus accounting metadata for block assembly."""
+
+    transaction: Transaction
+    fee: int
+    weight: int
+
+    @property
+    def fee_rate(self) -> float:
+        if self.weight <= 0:
+            raise ValueError("Transaction weight must be positive")
+        return self.fee / self.weight
+
+
+@dataclass(frozen=True)
+class RelayCommitment:
+    """Describe a fee-sharing payout for a relay peer."""
+
+    address: str
+    amount: int
+    memo: str | None = None
+
+    def build_outputs(self) -> List[TxOutput]:
+        script = address_to_script(self.address)
+        outputs = [TxOutput(value=self.amount, script_pubkey=script)]
+        if self.memo:
+            memo_bytes = self.memo.encode("utf8")
+            if len(memo_bytes) > 64:
+                raise ValueError("Relay memo exceeds 64 bytes")
+            outputs.append(_commitment_output(b"relay:" + memo_bytes))
+        return outputs
+
+
+@dataclass
+class MiningStats:
+    """Expose aggregate information about a mined block."""
+
+    height: int
+    total_fees: int
+    attempts: int
+    duration: float
+
+
+class Miner:
+    """Assemble block templates and iterate proof-of-work solutions."""
+
+    def __init__(
+        self,
+        chain_state: ChainState,
+        payout_address: str,
+        wallet: Optional[Wallet] = None,
+        *,
+        max_block_weight: int = _MAX_BLOCK_WEIGHT,
+    ) -> None:
+        self.chain_state = chain_state
+        self.payout_address = payout_address
+        self.wallet = wallet
+        self.max_block_weight = max_block_weight
+        self._extra_nonce = int.from_bytes(os.urandom(4), "big")
+        self._last_coinbase_reward = 0
+
+    def mine_block(
+        self,
+        candidates: Iterable[TxCandidate],
+        *,
+        relay_commitments: Sequence[RelayCommitment] | None = None,
+        timestamp: Optional[int] = None,
+        max_attempts: Optional[int] = None,
+    ) -> tuple[Optional[Block], MiningStats]:
+        """Attempt to mine a new block from the provided mempool candidates."""
+
+        start = time.time()
+        relay_commitments = tuple(relay_commitments or ())
+        selected, total_fees = self._select_transactions(candidates)
+        height = self.chain_state.height
+        block = self._create_candidate_block(
+            selected,
+            total_fees,
+            relay_commitments,
+            timestamp=timestamp,
+            height=height,
+        )
+
+        attempts = 0
+        solved = False
+        while True:
+            target_attempts = None if max_attempts is None else max_attempts - attempts
+            solved, made = self._solve_block(block, max_attempts=target_attempts)
+            attempts += made
+            if solved or (max_attempts is not None and attempts >= max_attempts):
+                break
+            self._extra_nonce = (self._extra_nonce + 1) & 0xFFFFFFFF
+            coinbase, miner_reward = self._coinbase_transaction(
+                height,
+                total_fees,
+                relay_commitments,
+                extra_nonce=self._extra_nonce,
+            )
+            self._last_coinbase_reward = miner_reward
+            block.transactions[0] = coinbase
+            block.update_merkle_root()
+            block.header.time = self._current_time(block.header.time)
+            block.header.nonce = 0
+
+        if solved:
+            self._register_coinbase(block)
+            duration = time.time() - start
+            stats = MiningStats(height=height, total_fees=total_fees, attempts=attempts, duration=duration)
+            return block, stats
+        duration = time.time() - start
+        stats = MiningStats(height=height, total_fees=total_fees, attempts=attempts, duration=duration)
+        return None, stats
+
+    def _select_transactions(self, candidates: Iterable[TxCandidate]) -> tuple[List[Transaction], int]:
+        remaining_weight = self.max_block_weight
+        selected: List[Transaction] = []
+        total_fees = 0
+        ordered = sorted(candidates, key=lambda c: c.fee_rate, reverse=True)
+        for candidate in ordered:
+            if candidate.weight > remaining_weight:
+                continue
+            selected.append(candidate.transaction)
+            remaining_weight -= candidate.weight
+            total_fees += candidate.fee
+        return selected, total_fees
+
+    def _create_candidate_block(
+        self,
+        transactions: Sequence[Transaction],
+        total_fees: int,
+        relay_commitments: Sequence[RelayCommitment],
+        *,
+        timestamp: Optional[int],
+        height: int,
+    ) -> Block:
+        prev_block = self.chain_state.chain[-1]
+        header = BlockHeader(
+            version=1,
+            prev_hash=prev_block.header.hash(),
+            merkle_root=b"\x00" * 32,
+            time=self._current_time(prev_block.header.time) if timestamp is None else max(timestamp, prev_block.header.time + 1),
+            bits=self.chain_state.target_for_height(height).bits,
+            nonce=0,
+        )
+        coinbase, miner_reward = self._coinbase_transaction(height, total_fees, relay_commitments, extra_nonce=self._extra_nonce)
+        self._last_coinbase_reward = miner_reward
+        block_transactions = [coinbase, *transactions]
+        block = Block(header=header, transactions=list(block_transactions))
+        block.update_merkle_root()
+        return block
+
+    def _coinbase_transaction(
+        self,
+        height: int,
+        total_fees: int,
+        relay_commitments: Sequence[RelayCommitment],
+        *,
+        extra_nonce: int,
+    ) -> tuple[Transaction, int]:
+        script_sig = _coinbase_script(height, extra_nonce)
+        subsidy = SUBSIDY_SCHEDULE.block_reward(height)
+        distributed = 0
+        commitment_outputs: List[TxOutput] = []
+        for commitment in relay_commitments:
+            distributed += commitment.amount
+            if distributed > total_fees:
+                raise ValueError("Relay commitments exceed total fees")
+            commitment_outputs.extend(commitment.build_outputs())
+        miner_reward = subsidy + (total_fees - distributed)
+        if miner_reward < 0:
+            raise ValueError("Negative miner reward computed")
+        outputs: List[TxOutput] = [
+            TxOutput(value=miner_reward, script_pubkey=address_to_script(self.payout_address)),
+            *commitment_outputs,
+        ]
+        tx = Transaction(
+            version=1,
+            inputs=[
+                TxInput(
+                    prev_txid=b"\x00" * 32,
+                    prev_index=0xFFFFFFFF,
+                    script_sig=script_sig,
+                    sequence=0,
+                )
+            ],
+            outputs=outputs,
+            locktime=0,
+        )
+        return tx, miner_reward
+
+    def _solve_block(self, block: Block, *, max_attempts: Optional[int]) -> tuple[bool, int]:
+        target = block.header.target
+        attempts = 0
+        while True:
+            block_hash = block.header.hash()[::-1]
+            attempts += 1
+            if int.from_bytes(block_hash, "big") <= target.to_target():
+                return True, attempts
+            block.header.nonce = (block.header.nonce + 1) & 0xFFFFFFFF
+            if block.header.nonce == 0:
+                return False, attempts
+            if max_attempts is not None and attempts >= max_attempts:
+                return False, attempts
+
+    def _register_coinbase(self, block: Block) -> None:
+        if self.wallet is None:
+            return
+        coinbase = block.transactions[0]
+        self.wallet.register_utxo(coinbase.txid(), 0, self._last_coinbase_reward, self.payout_address)
+
+    def _current_time(self, previous_time: int) -> int:
+        now = int(time.time())
+        if now <= previous_time:
+            return previous_time + 1
+        if now - previous_time > BLOCK_TARGET_INTERVAL:
+            return previous_time + BLOCK_TARGET_INTERVAL
+        return now
+
+
+def _coinbase_script(height: int, extra_nonce: int) -> bytes:
+    height_bytes = _encode_compact(height)
+    nonce_bytes = _encode_compact(extra_nonce)
+    return height_bytes + nonce_bytes + _encode_push(b"Irium miner")
+
+
+def _commitment_output(data: bytes) -> TxOutput:
+    if len(data) > 75:
+        raise ValueError("Commitment payload too large")
+    script = b"\x6a" + len(data).to_bytes(1, "big") + data
+    return TxOutput(value=0, script_pubkey=script)
+
+
+def _encode_compact(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("Value must be non-negative")
+    raw = value.to_bytes((value.bit_length() + 7) // 8 or 1, "little")
+    if raw[-1] & 0x80:
+        raw += b"\x00"
+    return len(raw).to_bytes(1, "big") + raw
+
+
+def _encode_push(data: bytes) -> bytes:
+    if len(data) >= 0x4C:
+        raise ValueError("Pushdata too large for coinbase message")
+    return len(data).to_bytes(1, "big") + data
+
+
+__all__ = [
+    "Miner",
+    "TxCandidate",
+    "RelayCommitment",
+    "MiningStats",
+]

--- a/irium/network.py
+++ b/irium/network.py
@@ -1,0 +1,133 @@
+"""Peer networking utilities for Irium's zero-DNS topology."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+SEEDLIST_PATH = Path("bootstrap/seedlist.txt")
+RUNTIME_SEEDLIST_PATH = Path("bootstrap/seedlist.runtime")
+PEER_DB_PATH = Path("state/peers.json")
+
+
+def _normalize_multiaddr(addr: str) -> str:
+    candidate = addr.strip()
+    if not candidate:
+        raise ValueError("Empty multiaddr")
+    if not candidate.startswith("/"):
+        raise ValueError("Multiaddr must start with '/'")
+    return candidate
+
+
+@dataclass
+class PeerRecord:
+    """Track observed peer metadata for auto-healing discovery."""
+
+    multiaddr: str
+    agent: Optional[str] = None
+    last_seen: float = field(default_factory=time.time)
+    first_seen: float = field(default_factory=time.time)
+
+    def touch(self) -> None:
+        self.last_seen = time.time()
+
+
+class SeedlistManager:
+    """Maintain a runtime seedlist that augments the signed release file."""
+
+    def __init__(self, baseline: Path = SEEDLIST_PATH, runtime: Path = RUNTIME_SEEDLIST_PATH, limit: int = 512) -> None:
+        self.baseline = baseline
+        self.runtime = runtime
+        self.limit = limit
+        self.runtime.parent.mkdir(parents=True, exist_ok=True)
+        if not self.runtime.exists():
+            header = "# Auto-generated runtime seedlist. Do not edit manually.\n"
+            self.runtime.write_text(header)
+
+    def _load_runtime_entries(self) -> Iterable[str]:
+        if not self.runtime.exists():
+            return []
+        entries = []
+        for line in self.runtime.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            entries.append(line)
+        return entries
+
+    def record_peer(self, multiaddr: str) -> None:
+        entry = _normalize_multiaddr(multiaddr)
+        entries = list(dict.fromkeys([entry, *self._load_runtime_entries()]))
+        entries = entries[: self.limit]
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        header = f"# Runtime seedlist refreshed {timestamp}\n"
+        body = "\n".join(entries) + "\n"
+        self.runtime.write_text(header + body)
+
+    def merged_seedlist(self) -> Iterable[str]:
+        baseline_entries = []
+        if self.baseline.exists():
+            for line in self.baseline.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                baseline_entries.append(line)
+        combined = list(dict.fromkeys([*baseline_entries, *self._load_runtime_entries()]))
+        return combined[: self.limit]
+
+
+class PeerDirectory:
+    """Persist peer observations and refresh the runtime seedlist."""
+
+    def __init__(self, db_path: Path = PEER_DB_PATH, seed_manager: Optional[SeedlistManager] = None) -> None:
+        self.db_path = db_path
+        self.seed_manager = seed_manager or SeedlistManager()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._records: Dict[str, PeerRecord] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.db_path.exists():
+            return
+        data = json.loads(self.db_path.read_text())
+        for multiaddr, payload in data.items():
+            record = PeerRecord(
+                multiaddr=multiaddr,
+                agent=payload.get("agent"),
+                first_seen=payload.get("first_seen", time.time()),
+                last_seen=payload.get("last_seen", time.time()),
+            )
+            self._records[multiaddr] = record
+
+    def _flush(self) -> None:
+        serialised = {
+            addr: {
+                "agent": record.agent,
+                "first_seen": record.first_seen,
+                "last_seen": record.last_seen,
+            }
+            for addr, record in self._records.items()
+        }
+        self.db_path.write_text(json.dumps(serialised, indent=2, sort_keys=True))
+
+    def register_connection(self, multiaddr: str, agent: Optional[str] = None) -> PeerRecord:
+        entry = _normalize_multiaddr(multiaddr)
+        record = self._records.get(entry)
+        if record is None:
+            record = PeerRecord(multiaddr=entry, agent=agent)
+            self._records[entry] = record
+        else:
+            record.touch()
+            if agent:
+                record.agent = agent
+        self.seed_manager.record_peer(entry)
+        self._flush()
+        return record
+
+    def peers(self) -> Iterable[PeerRecord]:
+        return sorted(self._records.values(), key=lambda record: record.last_seen, reverse=True)
+

--- a/irium/pow.py
+++ b/irium/pow.py
@@ -1,0 +1,52 @@
+"""Proof-of-Work utilities for Irium."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Target:
+    """Compact representation of the PoW target."""
+
+    bits: int
+
+    def to_target(self) -> int:
+        exponent = self.bits >> 24
+        mantissa = self.bits & 0xFFFFFF
+        if exponent <= 3:
+            value = mantissa >> (8 * (3 - exponent))
+        else:
+            value = mantissa << (8 * (exponent - 3))
+        return value
+
+    def difficulty(self) -> float:
+        base_target = Target(0x1d00ffff).to_target()
+        return base_target / self.to_target()
+
+    @classmethod
+    def from_target(cls, value: int) -> "Target":
+        exponent = (value.bit_length() + 7) // 8
+        if exponent <= 3:
+            mantissa = value << (8 * (3 - exponent))
+        else:
+            mantissa = value >> (8 * (exponent - 3))
+        if mantissa & 0x800000:
+            mantissa >>= 8
+            exponent += 1
+        bits = (exponent << 24) | (mantissa & 0xFFFFFF)
+        return cls(bits)
+
+
+def sha256d(data: bytes) -> bytes:
+    return hashlib.sha256(hashlib.sha256(data).digest()).digest()
+
+
+def header_hash(parts: Iterable[bytes]) -> bytes:
+    return sha256d(b"".join(parts))
+
+
+def meets_target(hash_bytes: bytes, target: Target) -> bool:
+    return int.from_bytes(hash_bytes, byteorder="big") <= target.to_target()

--- a/irium/tools/__init__.py
+++ b/irium/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tooling package for Irium."""

--- a/irium/tools/verify_bootstrap.py
+++ b/irium/tools/verify_bootstrap.py
@@ -1,0 +1,137 @@
+"""Verify signed bootstrap material for zero-DNS startup."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from irium.wallet import verify_der_signature
+
+BOOTSTRAP_PUBLIC_KEYS = {
+    "founder": "03ffb48b174908aa757487b8dbf39bb0a021f20572f865530891a243f59242c702",
+    "guardian": "02c5f1f7a54f60d2ba2c9fb3b7910e7198ff9d1de3c8c8fba34cb57ec9adadd9d6",
+}
+
+
+def hash_file(path: Path) -> bytes:
+    digest = hashlib.sha256()
+    with path.open("rb") as infile:
+        while chunk := infile.read(8192):
+            digest.update(chunk)
+    return digest.digest()
+
+
+def _load_seed_entries(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    entries = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        entries.append(line)
+    return entries
+
+
+def verify_seedlist(seed_path: Path, runtime_path: Path | None = None, signature_path: Path | None = None) -> Iterable[str]:
+    if not seed_path.exists():
+        raise FileNotFoundError(seed_path)
+    seeds = _load_seed_entries(seed_path)
+    if runtime_path is not None:
+        seeds.extend(_load_seed_entries(runtime_path))
+    unique = list(dict.fromkeys(seeds))
+    if not unique:
+        raise ValueError("Seedlist contains no usable entries")
+    if signature_path is not None:
+        verify_seedlist_signature(seed_path, signature_path)
+    return unique
+
+
+def verify_anchor(anchor_path: Path) -> None:
+    data = json.loads(anchor_path.read_text())
+    if "anchors" not in data:
+        raise ValueError("anchors.json missing anchors array")
+    for anchor in data["anchors"]:
+        digest = _anchor_digest(anchor)
+        signatures = anchor.get("signatures", [])
+        if not signatures:
+            raise ValueError("Anchor is missing signatures")
+        _verify_signatures(signatures, digest, f"anchor@{anchor.get('height')}")
+
+
+def verify_seedlist_signature(seed_path: Path, signature_path: Path) -> None:
+    data = json.loads(signature_path.read_text())
+    expected_hash = data.get("hash")
+    if not isinstance(expected_hash, str):
+        raise ValueError("Seedlist signature missing hash")
+    digest = hash_file(seed_path)
+    if expected_hash.lower() != digest.hex():
+        raise ValueError("Seedlist hash mismatch")
+    signatures = data.get("signatures", [])
+    if not signatures:
+        raise ValueError("Seedlist signature file missing signatures")
+    _verify_signatures(signatures, digest, "seedlist.txt")
+
+
+def _anchor_digest(anchor: dict) -> bytes:
+    try:
+        height = int(anchor["height"])
+        block_hash = bytes.fromhex(anchor["block_hash"])
+        timestamp = int(anchor["timestamp"])
+    except (KeyError, ValueError) as exc:
+        raise ValueError("Anchor entry missing required fields") from exc
+    if len(block_hash) != 32:
+        raise ValueError("Anchor block hash must be 32 bytes")
+    payload = (
+        height.to_bytes(4, "big", signed=False)
+        + block_hash
+        + timestamp.to_bytes(8, "big", signed=False)
+    )
+    return hashlib.sha256(payload).digest()
+
+
+def _verify_signatures(signatures: List[dict], digest: bytes, subject: str) -> None:
+    valid_count = 0
+    for entry in signatures:
+        signer = entry.get("signer")
+        signature_hex = entry.get("signature")
+        if signer not in BOOTSTRAP_PUBLIC_KEYS:
+            raise ValueError(f"Unknown signer '{signer}' in {subject}")
+        if not isinstance(signature_hex, str):
+            raise ValueError(f"Signature for {signer} in {subject} is not a string")
+        try:
+            signature = bytes.fromhex(signature_hex)
+        except ValueError as exc:
+            raise ValueError(f"Signature for {signer} in {subject} is not valid hex") from exc
+        pubkey = bytes.fromhex(BOOTSTRAP_PUBLIC_KEYS[signer])
+        if not verify_der_signature(pubkey, digest, signature):
+            raise ValueError(f"Signature verification failed for {signer} in {subject}")
+        valid_count += 1
+    if valid_count == 0:
+        raise ValueError(f"No valid signatures found for {subject}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=Path, required=True)
+    parser.add_argument("--runtime", type=Path, default=Path("bootstrap/seedlist.runtime"))
+    parser.add_argument("--seed-sig", type=Path, default=Path("bootstrap/seedlist.txt.sig"))
+    parser.add_argument("--anchors", type=Path, required=True)
+    args = parser.parse_args()
+
+    seeds = verify_seedlist(args.seed, args.runtime, args.seed_sig)
+    verify_anchor(args.anchors)
+    seed_hash = hash_file(args.seed)
+    print("Seedlist hash:", seed_hash.hex())
+    if args.runtime.exists():
+        print("Runtime seedlist hash:", hash_file(args.runtime).hex())
+    print("Combined peers:", len(seeds))
+    print("Anchors hash:", hash_file(args.anchors).hex())
+    print("Signatures verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/irium/tx.py
+++ b/irium/tx.py
@@ -1,0 +1,117 @@
+"""Transaction primitives for the Irium blockchain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .constants import MAX_MONEY
+from .pow import sha256d
+
+
+@dataclass(frozen=True)
+class TxInput:
+    prev_txid: bytes
+    prev_index: int
+    script_sig: bytes
+    sequence: int = 0xFFFFFFFF
+
+    def serialize(self) -> bytes:
+        if len(self.prev_txid) != 32:
+            raise ValueError("prev_txid must be 32 bytes")
+        if not (0 <= self.prev_index <= 0xFFFFFFFF):
+            raise ValueError("prev_index out of range")
+        if not (0 <= self.sequence <= 0xFFFFFFFF):
+            raise ValueError("sequence out of range")
+        if len(self.script_sig) > 0xFF:
+            raise ValueError("script_sig too large")
+        return (
+            len(self.prev_txid).to_bytes(1, "big")
+            + self.prev_txid
+            + self.prev_index.to_bytes(4, "little")
+            + len(self.script_sig).to_bytes(1, "big")
+            + self.script_sig
+            + self.sequence.to_bytes(4, "little")
+        )
+
+
+@dataclass(frozen=True)
+class TxOutput:
+    value: int
+    script_pubkey: bytes
+
+    def serialize(self) -> bytes:
+        if not (0 <= self.value <= MAX_MONEY):
+            raise ValueError("Output value out of range")
+        if len(self.script_pubkey) > 0xFF:
+            raise ValueError("script_pubkey too large")
+        return (
+            self.value.to_bytes(8, "little", signed=False)
+            + len(self.script_pubkey).to_bytes(1, "big")
+            + self.script_pubkey
+        )
+
+
+@dataclass(frozen=True)
+class Transaction:
+    version: int
+    inputs: List[TxInput]
+    outputs: List[TxOutput]
+    locktime: int = 0
+
+    def serialize(self) -> bytes:
+        if not (0 <= self.version <= 0xFFFFFFFF):
+            raise ValueError("version out of range")
+        if not (0 <= self.locktime <= 0xFFFFFFFF):
+            raise ValueError("locktime out of range")
+        if len(self.inputs) > 0xFF:
+            raise ValueError("Too many inputs for compact encoding")
+        if len(self.outputs) > 0xFF:
+            raise ValueError("Too many outputs for compact encoding")
+        result = self.version.to_bytes(4, "little")
+        result += len(self.inputs).to_bytes(1, "big")
+        for txin in self.inputs:
+            result += txin.serialize()
+        result += len(self.outputs).to_bytes(1, "big")
+        for txout in self.outputs:
+            result += txout.serialize()
+        result += self.locktime.to_bytes(4, "little")
+        return result
+
+    def txid(self) -> bytes:
+        return sha256d(self.serialize())[::-1]
+
+    def weight(self) -> int:
+        return len(self.serialize()) * 4
+
+    def fee(self, input_sum: int) -> int:
+        output_sum = sum(o.value for o in self.outputs)
+        return input_sum - output_sum
+
+
+def cltv_script(lock_height: int, pubkey_hash: bytes) -> bytes:
+    """Create a simple CLTV script locking coins until `lock_height`."""
+    if len(pubkey_hash) != 20:
+        raise ValueError("Expected 20-byte pubkey hash")
+    if lock_height < 0:
+        raise ValueError("Lock height must be non-negative")
+    lock_bytes = _encode_locktime(lock_height)
+    return (
+        lock_bytes
+        + b"\xb1"  # OP_CHECKLOCKTIMEVERIFY
+        + b"\x75"  # OP_DROP
+        + b"\x76\xa9"  # OP_DUP OP_HASH160
+        + b"\x14" + pubkey_hash
+        + b"\x88\xac"  # OP_EQUALVERIFY OP_CHECKSIG
+    )
+
+
+def _encode_locktime(value: int) -> bytes:
+    """Encode locktime as minimal push data."""
+    result = value.to_bytes((value.bit_length() + 7) // 8 or 1, "little")
+    if result[-1] & 0x80:
+        result += b"\x00"
+    length = len(result)
+    if length < 0x4c:
+        return bytes([length]) + result
+    raise ValueError("Locktime too large for simple encoding")

--- a/irium/wallet.py
+++ b/irium/wallet.py
@@ -1,0 +1,472 @@
+"""Deterministic key management and transaction builder for Irium."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .constants import PUBKEY_ADDRESS_PREFIX
+from .pow import sha256d
+from .tx import Transaction, TxInput, TxOutput
+
+
+# Secp256k1 domain parameters
+_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+_G = (
+    55066263022277343669578718895168534326250603453777594175500187360389116729240,
+    32670510020758816978083085130507043184471273380659243275938904335757337482424,
+)
+
+_BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _int_to_bytes(value: int, length: int) -> bytes:
+    return value.to_bytes(length, "big")
+
+
+def _hash160(payload: bytes) -> bytes:
+    sha = hashlib.sha256(payload).digest()
+    ripemd = hashlib.new("ripemd160")
+    ripemd.update(sha)
+    return ripemd.digest()
+
+
+def _encode_base58(data: bytes) -> str:
+    num = int.from_bytes(data, "big")
+    encode = ""
+    while num > 0:
+        num, rem = divmod(num, 58)
+        encode = _BASE58_ALPHABET[rem] + encode
+    pad = 0
+    for byte in data:
+        if byte == 0:
+            pad += 1
+        else:
+            break
+    return "1" * pad + encode
+
+
+def _decode_base58(data: str) -> bytes:
+    num = 0
+    for char in data:
+        num = num * 58 + _BASE58_ALPHABET.index(char)
+    combined = num.to_bytes((num.bit_length() + 7) // 8 or 1, "big")
+    pad = len(data) - len(data.lstrip("1"))
+    return b"\x00" * pad + combined
+
+
+def _base58_check_encode(payload: bytes) -> str:
+    checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    return _encode_base58(payload + checksum)
+
+
+def _base58_check_decode(data: str) -> bytes:
+    raw = _decode_base58(data)
+    if len(raw) < 4:
+        raise ValueError("Base58 payload too short")
+    payload, checksum = raw[:-4], raw[-4:]
+    expected = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
+    if checksum != expected:
+        raise ValueError("Checksum mismatch")
+    return payload
+
+
+def _inverse_mod(value: int, modulus: int) -> int:
+    return pow(value, -1, modulus)
+
+
+def _is_on_curve(point: Optional[Tuple[int, int]]) -> bool:
+    if point is None:
+        return True
+    x, y = point
+    return (y * y - (x * x * x + 7)) % _P == 0
+
+
+def _point_add(point1: Optional[Tuple[int, int]], point2: Optional[Tuple[int, int]]) -> Optional[Tuple[int, int]]:
+    if point1 is None:
+        return point2
+    if point2 is None:
+        return point1
+    x1, y1 = point1
+    x2, y2 = point2
+    if x1 == x2 and y1 != y2:
+        return None
+    if x1 == x2:
+        m = (3 * x1 * x1) * _inverse_mod(2 * y1 % _P, _P) % _P
+    else:
+        m = (y1 - y2) * _inverse_mod((x1 - x2) % _P, _P) % _P
+    x3 = (m * m - x1 - x2) % _P
+    y3 = (m * (x1 - x3) - y1) % _P
+    return x3, y3
+
+
+def _scalar_mult(k: int, point: Optional[Tuple[int, int]]) -> Optional[Tuple[int, int]]:
+    if k % _N == 0 or point is None:
+        return None
+    result: Optional[Tuple[int, int]] = None
+    addend = point
+    while k:
+        if k & 1:
+            result = _point_add(result, addend)
+        addend = _point_add(addend, addend)
+        k >>= 1
+    return result
+
+
+def _lift_x(x: int) -> Tuple[int, int]:
+    alpha = (x * x * x + 7) % _P
+    beta = pow(alpha, (_P + 1) // 4, _P)
+    if (_point := (x, beta)) and _is_on_curve(_point):
+        return _point
+    raise ValueError("Failed to lift x to curve")
+
+
+def _parse_public_key(data: bytes) -> Tuple[int, int]:
+    if len(data) == 33 and data[0] in (0x02, 0x03):
+        x = int.from_bytes(data[1:], "big")
+        x_point = _lift_x(x)
+        if (x_point[1] % 2 == 0) != (data[0] == 0x02):
+            x_point = (x_point[0], _P - x_point[1])
+        return x_point
+    if len(data) == 65 and data[0] == 0x04:
+        x = int.from_bytes(data[1:33], "big")
+        y = int.from_bytes(data[33:], "big")
+        point = (x, y)
+        if not _is_on_curve(point):
+            raise ValueError("Invalid uncompressed public key")
+        return point
+    raise ValueError("Unsupported public key format")
+
+
+def _deterministic_k(privkey: int, digest: bytes) -> int:
+    priv_bytes = _int_to_bytes(privkey, 32)
+    v = b"\x01" * 32
+    k = b"\x00" * 32
+    k = hmac.new(k, v + b"\x00" + priv_bytes + digest, hashlib.sha256).digest()
+    v = hmac.new(k, v, hashlib.sha256).digest()
+    k = hmac.new(k, v + b"\x01" + priv_bytes + digest, hashlib.sha256).digest()
+    v = hmac.new(k, v, hashlib.sha256).digest()
+    while True:
+        v = hmac.new(k, v, hashlib.sha256).digest()
+        candidate = int.from_bytes(v, "big")
+        if 1 <= candidate < _N:
+            return candidate
+        k = hmac.new(k, v + b"\x00", hashlib.sha256).digest()
+        v = hmac.new(k, v, hashlib.sha256).digest()
+
+
+def _encode_der(r: int, s: int) -> bytes:
+    def encode_int(value: int) -> bytes:
+        raw = value.to_bytes((value.bit_length() + 7) // 8 or 1, "big")
+        if raw[0] & 0x80:
+            raw = b"\x00" + raw
+        return raw
+
+    r_bytes = encode_int(r)
+    s_bytes = encode_int(s)
+    sequence = b"\x02" + len(r_bytes).to_bytes(1, "big") + r_bytes
+    sequence += b"\x02" + len(s_bytes).to_bytes(1, "big") + s_bytes
+    return b"\x30" + len(sequence).to_bytes(1, "big") + sequence
+
+
+def _decode_der(signature: bytes) -> Tuple[int, int]:
+    if len(signature) < 8 or signature[0] != 0x30:
+        raise ValueError("Invalid DER signature header")
+    total_len = signature[1]
+    if total_len + 2 != len(signature):
+        raise ValueError("DER length mismatch")
+    offset = 2
+    if signature[offset] != 0x02:
+        raise ValueError("DER missing R integer tag")
+    r_len = signature[offset + 1]
+    r_start = offset + 2
+    r_end = r_start + r_len
+    r = int.from_bytes(signature[r_start:r_end], "big")
+    offset = r_end
+    if signature[offset] != 0x02:
+        raise ValueError("DER missing S integer tag")
+    s_len = signature[offset + 1]
+    s_start = offset + 2
+    s_end = s_start + s_len
+    s = int.from_bytes(signature[s_start:s_end], "big")
+    if s_end != len(signature):
+        raise ValueError("Unexpected DER trailer")
+    if not (1 <= r < _N and 1 <= s < _N):
+        raise ValueError("Signature scalars out of range")
+    return r, s
+
+
+def _p2pkh_script(pubkey_hash: bytes) -> bytes:
+    if len(pubkey_hash) != 20:
+        raise ValueError("Invalid pubkey hash length")
+    return b"\x76\xa9\x14" + pubkey_hash + b"\x88\xac"
+
+
+def _encode_push(data: bytes) -> bytes:
+    if len(data) >= 0x4C:
+        raise ValueError("Pushdata too large for simple encoding")
+    return len(data).to_bytes(1, "big") + data
+
+
+def address_to_script(address: str) -> bytes:
+    """Convert a base58 P2PKH address into its locking script."""
+
+    payload = _base58_check_decode(address)
+    if payload[0] != PUBKEY_ADDRESS_PREFIX:
+        raise ValueError("Address prefix mismatch")
+    return _p2pkh_script(payload[1:])
+
+
+@dataclass
+class UTXO:
+    txid: bytes
+    index: int
+    value: int
+    address: str
+    script_pubkey: bytes
+
+
+@dataclass
+class KeyPair:
+    private_key: int
+    compressed: bool = True
+
+    @classmethod
+    def generate(cls) -> "KeyPair":
+        while True:
+            secret = secrets.randbelow(_N)
+            if 1 <= secret < _N:
+                return cls(secret)
+
+    @classmethod
+    def from_wif(cls, wif: str) -> "KeyPair":
+        payload = _base58_check_decode(wif)
+        if payload[0] != 0x80:
+            raise ValueError("Unsupported WIF prefix")
+        compressed = False
+        key_bytes = payload[1:]
+        if len(key_bytes) == 33 and key_bytes[-1] == 0x01:
+            compressed = True
+            key_bytes = key_bytes[:-1]
+        if len(key_bytes) != 32:
+            raise ValueError("Invalid key length")
+        secret = int.from_bytes(key_bytes, "big")
+        if not 1 <= secret < _N:
+            raise ValueError("Invalid secret exponent")
+        return cls(secret, compressed=compressed)
+
+    def to_wif(self) -> str:
+        payload = b"\x80" + _int_to_bytes(self.private_key, 32)
+        if self.compressed:
+            payload += b"\x01"
+        return _base58_check_encode(payload)
+
+    def public_point(self) -> Tuple[int, int]:
+        point = _scalar_mult(self.private_key, _G)
+        if point is None or not _is_on_curve(point):
+            raise ValueError("Derived invalid public point")
+        return point
+
+    def public_key(self) -> bytes:
+        x, y = self.public_point()
+        if self.compressed:
+            prefix = b"\x02" if y % 2 == 0 else b"\x03"
+            return prefix + _int_to_bytes(x, 32)
+        return b"\x04" + _int_to_bytes(x, 32) + _int_to_bytes(y, 32)
+
+    def address(self) -> str:
+        pubkey_hash = _hash160(self.public_key())
+        payload = bytes([PUBKEY_ADDRESS_PREFIX]) + pubkey_hash
+        return _base58_check_encode(payload)
+
+    def sign(self, digest: bytes) -> bytes:
+        if len(digest) != 32:
+            raise ValueError("Digest must be 32 bytes")
+        while True:
+            k = _deterministic_k(self.private_key, digest)
+            point = _scalar_mult(k, _G)
+            if point is None:
+                continue
+            r = point[0] % _N
+            if r == 0:
+                continue
+            k_inv = _inverse_mod(k, _N)
+            z = int.from_bytes(digest, "big")
+            s = (k_inv * (z + r * self.private_key)) % _N
+            if s == 0:
+                continue
+            if s > _N // 2:
+                s = _N - s
+            der = _encode_der(r, s)
+            return der + b"\x01"  # SIGHASH_ALL
+
+    def sign_raw(self, digest: bytes) -> bytes:
+        """Produce a canonical DER signature without a sighash byte."""
+
+        if len(digest) != 32:
+            raise ValueError("Digest must be 32 bytes")
+        while True:
+            k = _deterministic_k(self.private_key, digest)
+            point = _scalar_mult(k, _G)
+            if point is None:
+                continue
+            r = point[0] % _N
+            if r == 0:
+                continue
+            k_inv = _inverse_mod(k, _N)
+            z = int.from_bytes(digest, "big")
+            s = (k_inv * (z + r * self.private_key)) % _N
+            if s == 0:
+                continue
+            if s > _N // 2:
+                s = _N - s
+            return _encode_der(r, s)
+
+
+class Wallet:
+    """Manage key pairs, unspent outputs, and signed transactions."""
+
+    def __init__(self) -> None:
+        self._keys: Dict[str, KeyPair] = {}
+        self._utxos: Dict[Tuple[bytes, int], UTXO] = {}
+
+    def import_wif(self, wif: str) -> str:
+        key = KeyPair.from_wif(wif)
+        address = key.address()
+        self._keys[address] = key
+        return address
+
+    def new_address(self, compressed: bool = True) -> str:
+        key = KeyPair.generate()
+        key.compressed = compressed
+        address = key.address()
+        self._keys[address] = key
+        return address
+
+    def addresses(self) -> Iterable[str]:
+        return self._keys.keys()
+
+    def balance(self) -> int:
+        return sum(utxo.value for utxo in self._utxos.values())
+
+    def default_address(self) -> str:
+        try:
+            return next(iter(self._keys))
+        except StopIteration as exc:
+            raise RuntimeError("Wallet has no keys") from exc
+
+    def register_utxo(self, txid: bytes, index: int, value: int, address: Optional[str] = None) -> None:
+        owner = address or self.default_address()
+        key = self._keys.get(owner)
+        if key is None:
+            raise ValueError("Unknown address for wallet")
+        pubkey_hash = _hash160(key.public_key())
+        script_pubkey = _p2pkh_script(pubkey_hash)
+        utxo = UTXO(txid=txid, index=index, value=value, address=owner, script_pubkey=script_pubkey)
+        self._utxos[(txid, index)] = utxo
+
+    def _select_utxos(self, amount: int) -> Tuple[List[UTXO], int]:
+        sorted_utxos = sorted(self._utxos.values(), key=lambda utxo: utxo.value, reverse=True)
+        selected: List[UTXO] = []
+        total = 0
+        for utxo in sorted_utxos:
+            selected.append(utxo)
+            total += utxo.value
+            if total >= amount:
+                break
+        if total < amount:
+            raise ValueError("Insufficient funds")
+        return selected, total
+
+    def _address_to_script(self, address: str) -> bytes:
+        return address_to_script(address)
+
+    def create_transaction(self, payments: List[Tuple[str, int]], fee: int = 0) -> Transaction:
+        if not payments:
+            raise ValueError("At least one payment required")
+        total_out = sum(amount for _, amount in payments) + fee
+        utxos, gathered = self._select_utxos(total_out)
+        change = gathered - total_out
+        inputs = [
+            TxInput(prev_txid=utxo.txid, prev_index=utxo.index, script_sig=b"")
+            for utxo in utxos
+        ]
+        outputs = [
+            TxOutput(value=amount, script_pubkey=self._address_to_script(address))
+            for address, amount in payments
+        ]
+        if change > 0:
+            change_address = utxos[0].address
+            outputs.append(TxOutput(value=change, script_pubkey=self._address_to_script(change_address)))
+        unsigned = Transaction(version=1, inputs=inputs, outputs=outputs)
+        signed_inputs = []
+        for idx, utxo in enumerate(utxos):
+            key = self._keys[utxo.address]
+            sighash = self._signature_hash(unsigned, idx, utxo.script_pubkey)
+            signature = key.sign(sighash)
+            script_sig = _encode_push(signature) + _encode_push(key.public_key())
+            signed_inputs.append(
+                TxInput(
+                    prev_txid=utxo.txid,
+                    prev_index=utxo.index,
+                    script_sig=script_sig,
+                    sequence=0xFFFFFFFF,
+                )
+            )
+        final_tx = Transaction(version=unsigned.version, inputs=signed_inputs, outputs=unsigned.outputs, locktime=unsigned.locktime)
+        for utxo in utxos:
+            self._utxos.pop((utxo.txid, utxo.index), None)
+        if change > 0:
+            txid = final_tx.txid()
+            change_index = len(outputs) - 1
+            self.register_utxo(txid, change_index, change, utxos[0].address)
+        return final_tx
+
+    def _signature_hash(self, tx: Transaction, input_index: int, script_pubkey: bytes) -> bytes:
+        tmp_inputs = []
+        for idx, txin in enumerate(tx.inputs):
+            script = script_pubkey if idx == input_index else b""
+            tmp_inputs.append(
+                TxInput(
+                    prev_txid=txin.prev_txid,
+                    prev_index=txin.prev_index,
+                    script_sig=script,
+                    sequence=txin.sequence,
+                )
+            )
+        temp_tx = Transaction(version=tx.version, inputs=tmp_inputs, outputs=tx.outputs, locktime=tx.locktime)
+        serialized = temp_tx.serialize() + b"\x01\x00\x00\x00"  # SIGHASH_ALL
+        return sha256d(serialized)
+
+
+def verify_der_signature(pubkey: bytes, digest: bytes, signature: bytes) -> bool:
+    """Verify a DER-encoded secp256k1 signature against `digest`."""
+
+    if len(digest) != 32:
+        raise ValueError("Digest must be 32 bytes")
+    try:
+        point = _parse_public_key(pubkey)
+        r, s = _decode_der(signature)
+    except ValueError:
+        return False
+    z = int.from_bytes(digest, "big")
+    s_inv = _inverse_mod(s, _N)
+    u1 = (z * s_inv) % _N
+    u2 = (r * s_inv) % _N
+    check = _point_add(_scalar_mult(u1, _G), _scalar_mult(u2, point))
+    if check is None:
+        return False
+    return check[0] % _N == r
+
+
+__all__ = [
+    "KeyPair",
+    "Wallet",
+    "verify_der_signature",
+    "address_to_script",
+]
+

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,182 @@
-irium
+# Irium Mainnet
+
+Irium is an original proof-of-work blockchain engineered specifically for the IRM asset. The network targets mainnet readiness only—no testnet or demo deployments are packaged in this repository. Every component was designed and implemented for Irium to support DNS-free bootstrapping, self-healing peer discovery, and enforceable genesis vesting without forking existing chains.
+
+## Table of Contents
+- [Network Specifications](#network-specifications)
+- [Repository Layout](#repository-layout)
+- [Getting Started](#getting-started)
+- [Bootstrapping Without DNS](#bootstrapping-without-dns)
+- [Automatic Peer Persistence](#automatic-peer-persistence)
+- [Genesis Configuration](#genesis-configuration)
+- [Consensus & Monetary Policy](#consensus--monetary-policy)
+- [P2P & Security Enhancements](#p2p--security-enhancements)
+- [Light Client Support](#light-client-support)
+- [Wallet Integration](#wallet-integration)
+- [Mining Toolkit](#mining-toolkit)
+- [Development Roadmap](#development-roadmap)
+- [Licensing](#licensing)
+
+## Network Specifications
+
+| Parameter | Value |
+|-----------|-------|
+| Ticker | IRM |
+| Consensus | Proof-of-Work (SHA-256d) |
+| Block Target | 600 seconds |
+| Block Subsidy | 50 IRM (blocks 1–1,930,000) |
+| Halving Interval | None – constant subsidy until mining supply exhausted |
+| Coinbase Maturity | 100 blocks |
+| Difficulty Retarget | 2016 blocks |
+| Maximum Supply | 100,000,000 IRM |
+| Founder Vesting | 3,500,000 IRM CLTV-locked for 3 years |
+| Public Distribution | 96,500,000 IRM mined over 1,930,000 blocks |
+
+## Repository Layout
+
+```
+irium/                  # Reference Python primitives for blocks, PoW, transactions, and chain state
+  network.py            # Auto-updating peer directory and runtime seedlist management
+  wallet.py             # Deterministic key management and transaction builder
+configs/genesis.json    # Canonical genesis coinbase layout with CLTV vesting commitments
+bootstrap/              # Signed seedlist & rolling anchors for DNS-free initialization
+  seedlist.runtime      # Node-maintained seed cache refreshed on each inbound connection
+scripts/                # Helper scripts (zero-DNS launcher, deterministic genesis builder)
+docs/architecture.md    # Protocol high-level architecture
+docs/whitepaper.md      # Formal whitepaper capturing protocol rationale and economics
+state/                  # Runtime data (peer book, wallet metadata) produced by mainnet nodes
+LICENSE                 # Project license
+```
+
+No test or demo files are shipped alongside the mainnet resources, ensuring the repository mirrors the production deployment surface.
+
+## Getting Started
+
+1. Install Python 3.11 or later.
+2. Clone this repository.
+3. Review `docs/whitepaper.md` for a deep dive into protocol goals and implementation notes.
+4. Build the genesis artifacts using `python scripts/create_genesis.py` if you need to regenerate the canonical block header.
+5. Launch the zero-DNS bootstrap helper as described below to obtain seed peers and anchor checkpoints.
+
+## Bootstrapping Without DNS
+
+Run the provided script to fetch and validate bootstrap artifacts:
+
+```bash
+./scripts/irium-zero.sh
+```
+
+The helper script performs the following steps:
+1. Downloads or reads bundled `seedlist.txt` and `anchors.json` artifacts.
+2. Verifies detached secp256k1 signatures using the bundled founder/guardian public keys.
+3. Exports multiaddresses for libp2p-compatible dialing.
+4. Emits the latest anchor checkpoints that new nodes should validate when syncing headers.
+
+This workflow eliminates DNS dependencies entirely. Mirrors can be distributed via GitHub Releases, IPFS, or torrent bundles to ensure long-term availability.
+
+## Automatic Peer Persistence
+
+Nodes call into `irium.network.PeerDirectory` whenever a new libp2p peer completes its handshake. The peer directory persists metadata to `state/peers.json` and simultaneously refreshes `bootstrap/seedlist.runtime` with the observed multiaddress. This runtime seed cache complements the signed release seedlist without mutating its detached signature, ensuring fresh peers are always available—even if the founding mirrors disappear.
+
+Any tooling consuming the seed material should read both `seedlist.txt` and `seedlist.runtime` (the helper already merges them) to take advantage of the automatically collected peers.
+
+## Genesis Configuration
+
+`configs/genesis.json` encodes the deterministic genesis distribution:
+- A single CLTV-bound UTXO locks the founder’s 3,500,000 IRM allocation for three full years before the key can spend it.
+- No other parties receive genesis funds; 96,500,000 IRM remain unminted so miners can earn them through proof-of-work.
+- The `scripts/create_genesis.py` utility constructs the genesis block header, transaction merkle root, and subsidy schedule directly from this configuration.
+
+## Consensus & Monetary Policy
+
+Irium fixes the entire 100 million IRM supply while reserving 96.5 million IRM for proof-of-work mining:
+- Blocks target a 600-second interval with SHA-256d proof-of-work and retarget every 2016 blocks.
+- Blocks 1 through 1,930,000 each award a 50 IRM subsidy (5,000,000,000 satoshis); afterwards coinbase rewards drop to zero and miners rely on transaction fees only.
+- Genesis mints exactly 3,500,000 IRM into a three-year CLTV UTXO, keeping the remaining 96,500,000 IRM available for miners without any pre-allocation.
+- Coinbase outputs mature after 100 confirmations to deter short-term reorg incentives.
+- `ChainState` enforces value conservation by verifying that every coinbase transaction is limited to the permitted subsidy plus collected fees, so miners cannot inflate supply or create negative fee situations.
+
+The reference Python modules under `irium/` implement block serialization, PoW validation, difficulty computation, and deterministic chain state transitions without relying on external blockchain libraries. `ChainState` now enforces header continuity, merkle root integrity, proof-of-work targets, and coinbase reward limits while maintaining the UTXO set for transaction validation.
+
+## P2P & Security Enhancements
+
+Key networking innovations include:
+- **Zero-DNS Bootstrap:** Nodes trust only signed seed/anchor artifacts, never DNS seeds.
+- **Self-Healing Peer Discovery:** libp2p gossip tracks uptime proofs to keep a rolling catalog of reachable peers.
+- **Sybil-Hard Handshakes:** Ephemeral keys prove uptime via lightweight PoW/time-bound tokens to mitigate botnet flooding.
+- **Anchor-File Consensus:** Signed `anchors.json` files provide rolling checkpoints that harden clients against eclipse attacks.
+- **On-Chain Metadata Commitments:** Miners can commit hash pointers to off-chain resources in coinbase transactions without bloating the chain.
+- **Hard Supply Guardrails:** Full nodes now reject malformed transactions or coinbases that attempt to overflow output values or exceed the fixed 100 million IRM supply cap.
+
+## Light Client Support
+
+Irium ships with SPV-ready primitives from day one. The `irium` Python package exposes header validation and proof verification utilities that light wallets can leverage alongside anchor checkpoints to validate transactions without a full node.
+
+## Wallet Integration
+
+The reference `irium.wallet.Wallet` class turns the cryptographic primitives into a usable hot wallet:
+
+- Import existing keys via WIF (including the founder key) or generate new compressed/uncompressed key pairs.
+- Maintain a catalog of wallet-controlled UTXOs and query balances in satoshis.
+- Build and sign P2PKH transactions using deterministic RFC6979 ECDSA, automatically selecting change outputs and refreshing wallet state.
+
+Example usage:
+
+```python
+from irium.wallet import Wallet
+
+wallet = Wallet()
+founder_address = wallet.import_wif("Kx1xjP2wbj7YtrxbLoqGqX1wywkitU6vUxaPyHtVnFQw7sJutJXq")
+wallet.register_utxo(bytes.fromhex("00" * 32), 0, 1_0000_0000, founder_address)
+tx = wallet.create_transaction([(founder_address, 10_0000_0000)], fee=1000)
+print(tx.serialize().hex())
+```
+
+Wallet metadata can be stored alongside the peer directory under `state/` (the repository only tracks an empty placeholder to reserve the path, keeping private keys out of version control).
+
+## Mining Toolkit
+
+`irium.miner` ships a reference miner that assembles block templates, encodes relay reward commitments, and iterates nonces without depending on external blockchain stacks.
+
+- `Miner` takes a `ChainState`, payout address, and optional `Wallet`. It selects the highest fee-rate transactions from provided `TxCandidate` objects, constructs the coinbase, and cycles the extra nonce when the 32-bit nonce space is exhausted.
+- `RelayCommitment` lets miners dedicate a portion of collected fees to the peers that relayed transactions. Each commitment adds a standard P2PKH output, plus an optional `OP_RETURN` memo for auditable fee-sharing records.
+- `MiningStats` surfaces runtime metrics (height, total fees, attempts, elapsed time) for monitoring dashboards.
+- When a wallet instance is supplied, solved coinbase payouts are registered automatically for balance tracking (respect the 100-block coinbase maturity before spending).
+
+Example usage:
+
+```python
+from irium import ChainParams, ChainState, Miner, TxCandidate
+from irium.pow import Target
+
+# `genesis_block` and `pow_limit` come from configs/genesis.json and network parameters
+params = ChainParams(genesis_block=genesis_block, pow_limit=Target(0x1d00ffff))
+chain = ChainState(params=params)
+
+# `tx` is a Transaction prepared elsewhere (for example by irium.wallet)
+miner = Miner(chain_state=chain, payout_address="IRmExamplePayoutAddr...")
+block, stats = miner.mine_block([
+    TxCandidate(transaction=tx, fee=1500, weight=tx.weight())
+], max_attempts=100_000)
+
+if block:
+    print("Solved block in", stats.attempts, "attempts")
+    chain.connect_block(block)
+else:
+    print("No solution within attempt budget; retry with new timestamp/extra nonce")
+```
+
+Because mainnet difficulty is high, real deployments distribute the work across dedicated mining hardware while still relying on the shared block assembly logic for deterministic coinbase construction and relay reward accounting.
+
+## Development Roadmap
+
+Upcoming focus areas include:
+- Implementing the libp2p gossip layer with relay incentive accounting.
+- Finalizing production key material for bootstrap artifact signing.
+- Extending the Python primitives into a full node daemon and graphical SPV wallet.
+- Conducting third-party audits of the genesis configuration and bootstrap tooling.
+
+## Licensing
+
+The project is distributed under the terms of the MIT License. See [LICENSE](LICENSE) for the full text.
+

--- a/scripts/create_genesis.py
+++ b/scripts/create_genesis.py
@@ -1,0 +1,71 @@
+"""Create the Irium genesis block definition."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List
+
+from irium.block import Block, BlockHeader
+from irium.constants import GENESIS_BLOCK_HEIGHT
+from irium.pow import Target, sha256d
+from irium.tx import Transaction, TxInput, TxOutput
+
+
+@dataclass
+class GenesisAllocation:
+    amount: int
+    script_pubkey: str
+
+
+def create_genesis_block(timestamp: int, bits: int, nonce: int, allocations: List[GenesisAllocation]) -> Block:
+    coinbase_script = b"Irium genesis block"
+    coinbase_tx = Transaction(
+        version=1,
+        inputs=[TxInput(prev_txid=b"\x00" * 32, prev_index=0xFFFFFFFF, script_sig=coinbase_script)],
+        outputs=[TxOutput(value=a.amount, script_pubkey=bytes.fromhex(a.script_pubkey)) for a in allocations],
+        locktime=0,
+    )
+
+    header = BlockHeader(
+        version=1,
+        prev_hash=b"\x00" * 32,
+        merkle_root=coinbase_tx.txid(),
+        time=timestamp,
+        bits=bits,
+        nonce=nonce,
+    )
+    return Block(header=header, transactions=[coinbase_tx])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timestamp", type=int, required=True)
+    parser.add_argument("--bits", type=lambda x: int(x, 16), required=True)
+    parser.add_argument("--nonce", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--allocation", action="append", nargs=2, metavar=("amount", "script"), default=[])
+    args = parser.parse_args()
+
+    allocations = [GenesisAllocation(amount=int(amount), script_pubkey=script) for amount, script in args.allocation]
+    genesis_block = create_genesis_block(args.timestamp, args.bits, args.nonce, allocations)
+    data = {
+        "height": GENESIS_BLOCK_HEIGHT,
+        "header": {
+            "version": genesis_block.header.version,
+            "prev_hash": genesis_block.header.prev_hash.hex(),
+            "merkle_root": genesis_block.header.merkle_root.hex(),
+            "time": genesis_block.header.time,
+            "bits": f"{genesis_block.header.bits:08x}",
+            "nonce": genesis_block.header.nonce,
+            "hash": genesis_block.header.hash().hex(),
+        },
+        "transactions": [tx.serialize().hex() for tx in genesis_block.transactions],
+    }
+    args.output.write_text(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/irium-zero.sh
+++ b/scripts/irium-zero.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BOOTSTRAP_DIR="$ROOT_DIR/bootstrap"
+VERIFY_BIN="python3 -m irium.tools.verify_bootstrap"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required" >&2
+  exit 1
+fi
+
+python3 -m irium.tools.verify_bootstrap \
+  --seed "$BOOTSTRAP_DIR/seedlist.txt" \
+  --runtime "$BOOTSTRAP_DIR/seedlist.runtime" \
+  --seed-sig "$BOOTSTRAP_DIR/seedlist.txt.sig" \
+  --anchors "$BOOTSTRAP_DIR/anchors.json"
+
+printf '\nBootstrap material verified. Exporting seeds...\n'
+python3 - "$BOOTSTRAP_DIR" <<'PY'
+import sys
+from pathlib import Path
+
+from irium.tools.verify_bootstrap import verify_seedlist
+
+root = Path(sys.argv[1])
+for entry in verify_seedlist(root / "seedlist.txt", root / "seedlist.runtime"):
+    print(entry)
+PY


### PR DESCRIPTION
## Summary
- enforce strict bounds on transaction serialization to reject oversized scripts, indices, and version fields
- make ChainState track issued subsidy, cap new coinbase payouts against the remaining fixed supply, and validate output values before mutating the UTXO set
- document the additional supply guardrails in the README, architecture overview, and whitepaper

## Testing
- python -m compileall irium
- python3 -m irium.tools.verify_bootstrap --seed bootstrap/seedlist.txt --runtime bootstrap/seedlist.runtime --seed-sig bootstrap/seedlist.txt.sig --anchors bootstrap/anchors.json

------
https://chatgpt.com/codex/tasks/task_e_68ed6bc5081083229aa52b76a99a3e4b