### PR TITLE
Update iriumd.rs - allow --version or -v to be displayed from iriumd and exit

### DIFF
--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -15013,6 +15013,13 @@ async fn run_ltc_header_sync_cycle(
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 8)]
 async fn main() {
+    // Added to allow --version to be displayed
+    let args: Vec<String> = std::env::args().collect();
+    if args.contains(&"--version".to_string()) || args.contains(&"-v".to_string()) {
+        println!("iriumd version {}", env!("CARGO_PKG_VERSION"));
+        std::process::exit(0);
+    }
+    // -----------------------
     // Install ring as the default rustls crypto provider before any TLS code runs.
     // When both ring and aws-lc-rs appear in the dep tree, rustls 0.23 panics
     // unless install_default() is called explicitly (e.g. on nodes using TLS RPC).


### PR DESCRIPTION
allow --version or -v to be displayed from iriumd and exit

## Summary
Added --version and -v CLI flags to iriumd. The program now prints the binary version string and exits before initializing any network or consensus services.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Consensus change (requires extra review)
- [ ] Documentation update
- [ ] Wallet / CLI change

## Testing
Commands run and output:
cargo clean
cargo build --release --workspace --features gpu

$ /home/rodb/irium/target/release/iriumd --version
iriumd version 1.1.3
$ /home/rodb/irium/target/release/iriumd -v
iriumd version 1.1.3

If you also update, Cargo.toml with the Git Tag and compile:

$ /home/rodb/irium/target/release/iriumd --version
iriumd version 1.9.97
$ /home/rodb/irium/target/release/iriumd -v
iriumd version 1.9.97

## Consensus files unchanged
- [x] src/chain.rs not modified
- [x] src/pow.rs not modified
- [x] src/consensus.rs not modified
- [x] src/activation.rs not modified
- [x] src/settlement.rs not modified

(If any consensus file was modified, explain why and what the impact is.)

None

## Related issues
Closes #
