### PR TITLE
Delegation signup tooling (Steps A/B/D/F + docs) - CI/visibility only, do not merge

### DIFF
--- a/docs/miner-direct-pool-rewards.md
+++ b/docs/miner-direct-pool-rewards.md
@@ -1,0 +1,161 @@
+# Getting Paid Directly: One-Time Pool Setup for Irium Miners
+
+> **Status:** the tooling below is built and tested against isolated test environments.
+> **Full live end-to-end testing against a production pool is still pending** (the pool
+> infrastructure is being stood up). This guide describes accurately *how it works*; it does
+> not claim it has been exercised against the live pool yet. Command names and syntax are
+> final.
+
+## The short version
+
+Irium's pool can pay your mining rewards **straight to your own wallet address, on the
+blockchain**, instead of only tracking them off-chain. Turning this on is a **one-time step**
+you do once from your wallet — then you go back to mining exactly as you do today.
+
+**You do not have to do this.** If you skip it, nothing changes: you keep getting paid the
+same fair way you're paid now, through the pool's existing tracking. This is purely an upgrade
+for miners who want their rewards paid directly to their own address on-chain.
+
+---
+
+## Why is a one-time step even needed?
+
+Irium uses a mining system called **PoAW-X**. Alongside the normal hashing your ASIC does, the
+network requires a small cryptographic **"proof of eligibility"** (a VRF proof) to accompany
+each block, proving *who* is allowed to produce it. **ASIC miners physically cannot produce
+that proof** — they're purpose-built to hash, and nothing else.
+
+So the pool performs that proving step **on your behalf**. But for the blockchain to then pay
+a reward **directly to your address**, it needs your permission — a one-time note, signed by
+your wallet, that says:
+
+> "I authorise this pool to do the eligibility proving for me, and to pay my share to **my**
+> address."
+
+That signed note is called a **delegation**. You create it once. After that, the pool can pay
+you directly on-chain, block after block, with no further action from you. It's like setting up
+direct deposit: sign one form once, and your pay lands in your account automatically.
+
+---
+
+## What changes after you sign up — and what stays the same
+
+**What changes (the upside):**
+- Your **PRIMARY mining reward is paid directly to your own wallet address, on-chain**, in the
+  blocks you help produce — yours immediately, verifiable on the block explorer.
+
+**What stays exactly the same:**
+- You **still just point your ASIC at the pool and mine normally.** No new mining software, no
+  miner config changes, no change to how you connect.
+- The pool still does all the PoAW-X proving for you.
+- Your hardware, hashrate, and electricity — all unchanged.
+
+**If you do NOT sign up:**
+- **Nothing breaks and nothing is lost.** You keep being paid the same way you are today — the
+  pool tracks your fair share by the work your miner submits and pays you through its existing
+  process. You are not penalised or excluded; you mine exactly as before.
+
+---
+
+## How to sign up
+
+Two ways — pick whichever you're comfortable with. Both do the same thing.
+
+### Method A — Command line (`irium-wallet`)
+
+**Sign up (one command):**
+
+```
+irium-wallet delegate-pool <your-wallet-address> \
+    --pool <pool-delegation-url> \
+    --worker <your-worker-name> \
+    --expiry-height <height>
+```
+
+- It fetches the pool's identity (the pool's keys, including the custodial proposer key),
+  signs a delegation with **your wallet key** (which never leaves your machine), and submits it.
+- On success it prints a confirmation **and your `deleg_nonce`** — **save that value**; you
+  need it if you ever want to revoke (see below).
+
+**Offline variant** (air-gapped wallet; the operator supplies the pool's public keys and
+submits the result for you):
+
+```
+irium-wallet delegate-pool <your-wallet-address> --emit-only \
+    --pool-pubkey <66-hex> --proposer-pubkey <66-hex> --network-id <id> \
+    --worker <name> --expiry-height <height>
+```
+
+This prints a JSON payload (public data only — never your private key) to hand to the operator.
+
+**Check your delegation status** (are you delegated, to which worker, expiry, nonce):
+the app surfaces this; the pool exposes it at `GET /poawx/delegation-status?miner_pkh=<pkh>`.
+
+**Check your proposer status** (only relevant if you mine solo, not via the pool):
+`GET /poawx/proposer-status?pkh=<pkh>` reports whether your key is registered and eligible.
+
+### Method B — Irium Core app
+
+> The app controls exist and are wired to the real commands, but the **visual design is still a
+> functional stub** — polish is pending. The flow works; it just isn't styled yet.
+
+1. Open Irium Core and **unlock your wallet** (the same unlock you already use).
+2. Enter your **wallet address** and the **pool delegation URL**, then click
+   **"Enable direct pool rewards"**.
+3. You'll see a confirmation including your `deleg_nonce` (save it).
+4. **"Check delegation status"** shows whether you're delegated; **"Check proposer status"**
+   shows solo-proposer registration. Done — go mine as normal.
+
+---
+
+## Undoing it (revocation)
+
+You can cancel a delegation. **Important:** revocation is currently **on-chain only** — it is
+**not instant** like signup. You generate a signed revocation and **hand it to the pool
+operator**, who embeds it on-chain; it takes effect once included in a block.
+
+**CLI:**
+```
+irium-wallet revoke-delegation --addr <your-wallet-address> \
+    --deleg-nonce <the-nonce-from-signup> --network-id <id>
+```
+This prints a signed revocation hex — give it to the operator. In the app, the **"Generate
+revocation"** button does the same (generate-and-hand-off). After it's on-chain, the network
+stops paying you delegated rewards and you fall back to the pool's off-chain fair tracking.
+
+---
+
+## Frequently asked questions
+
+**Do I have to do this?**
+No. It's completely optional. Skip it and you're paid exactly as you are today.
+
+**What happens if I don't?**
+Nothing changes. The pool keeps tracking your fair share by the work your miner submits and
+pays you through its existing process. Nothing is lost, nothing breaks.
+
+**Is this safe? What does the signature actually authorise?**
+The one-time signature authorises the pool to do the PoAW-X eligibility proving on your behalf
+and to direct your PRIMARY reward to the address you chose. It does **not** give the pool
+access to your wallet, your coins, or your private keys, and it **cannot** spend or move your
+funds — it only names *where* the network pays your mining reward. Your signing key never
+leaves your wallet; only public data and a signature are sent.
+
+**Can I undo it?**
+Yes — with a revocation (see above). Note it is on-chain only right now, so it takes effect
+when the operator includes it in a block, not instantly.
+
+**Do I need to keep the app or CLI running?**
+No. Signup is a one-time action. Afterward you just mine normally; nothing needs to stay open.
+
+---
+
+## Known limitation (for reviewers)
+
+The signup, status, revoke, and proposer-status paths have been built and tested against
+**isolated test environments** (isolated node + pool harnesses, real HTTP round-trips, real
+signed delegations/revocations). **The full live path — the Irium Core app talking to a real
+production pool, with visual polish — has not yet been exercised end-to-end**, because the
+production pool infrastructure (custodial proposer key registration, the live delegation
+endpoint) is still being stood up. This guide describes the intended, built behaviour; the
+final live verification will happen when that infrastructure is ready.

--- a/pool/irium-stratum/src/delegation.rs
+++ b/pool/irium-stratum/src/delegation.rs
@@ -4598,6 +4598,78 @@ async fn handle_conn(mut stream: TcpStream, ctx: Arc<ServerCtx>) {
                 respond(&mut stream, 200, "OK", &v).await
             }
         },
+        ("GET", "/poawx/delegation-status") => {
+            // Step D: report whether a miner (by payout pkh) has delegations on file, with
+            // each worker's expiry_height and deleg_nonce (the latter lets the app populate
+            // the revoke flow). Loopback-only; 503 on mainnet like the rest of the server.
+            let store = match &ctx.producer {
+                Some(p) => &p.store,
+                None => {
+                    respond(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        &serde_json::json!({"error":"delegation unavailable on mainnet"}),
+                    )
+                    .await;
+                    return;
+                }
+            };
+            let query = path.split('?').nth(1).unwrap_or("");
+            let miner_pkh = query
+                .split('&')
+                .find_map(|kv| {
+                    let mut it = kv.splitn(2, '=');
+                    if it.next() == Some("miner_pkh") {
+                        it.next()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or("")
+                .to_string();
+            if miner_pkh.len() != 40 || hex::decode(&miner_pkh).is_err() {
+                respond(
+                    &mut stream,
+                    400,
+                    "Bad Request",
+                    &serde_json::json!({"error":"miner_pkh query param required (40 hex)"}),
+                )
+                .await;
+                return;
+            }
+            let entries: Vec<serde_json::Value> = store
+                .all_active(0)
+                .into_iter()
+                .filter(|d| d.miner_pkh.eq_ignore_ascii_case(&miner_pkh))
+                .map(|d| {
+                    // deleg_nonce lives at wire offset 130..162 of the delegation.
+                    let nonce = hex::decode(&d.delegation_hex)
+                        .ok()
+                        .filter(|b| b.len() >= 162)
+                        .map(|b| hex::encode(&b[130..162]))
+                        .unwrap_or_default();
+                    serde_json::json!({
+                        "worker": d.worker,
+                        "expiry_height": d.expiry_height,
+                        "network_id": d.network_id,
+                        "status": d.status,
+                        "deleg_nonce": nonce,
+                    })
+                })
+                .collect();
+            respond(
+                &mut stream,
+                200,
+                "OK",
+                &serde_json::json!({
+                    "miner_pkh": miner_pkh,
+                    "delegated": !entries.is_empty(),
+                    "delegations": entries,
+                }),
+            )
+            .await;
+        }
         ("POST", "/poawx/delegation") => {
             let (key, store) = match &ctx.producer {
                 Some(p) => (&p.key, &p.store),
@@ -4873,6 +4945,40 @@ mod tests {
         )
         .expect("proposer-bound delegation accepted by verify_and_store");
         assert_eq!(stored.miner_pkh, hex::encode(d.miner_pkh()), "stored under miner pkh");
+
+        // Step D: GET /poawx/delegation-status reports the miner as delegated + the nonce.
+        let miner_pkh_hex = hex::encode(d.miner_pkh());
+        let st: serde_json::Value = client
+            .get(format!(
+                "http://{bind}/poawx/delegation-status?miner_pkh={miner_pkh_hex}"
+            ))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(st["delegated"].as_bool(), Some(true), "status: delegated");
+        let entry = &st["delegations"][0];
+        assert_eq!(entry["expiry_height"].as_u64(), Some(10_000_000));
+        assert_eq!(
+            entry["deleg_nonce"].as_str().unwrap_or(""),
+            hex::encode([7u8; 32]),
+            "status returns the deleg_nonce for revoke"
+        );
+        // an unrelated pkh is not delegated.
+        let none: serde_json::Value = client
+            .get(format!(
+                "http://{bind}/poawx/delegation-status?miner_pkh={}",
+                hex::encode([0x99u8; 20])
+            ))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(none["delegated"].as_bool(), Some(false), "unrelated pkh not delegated");
 
         for k in [
             "IRIUM_NETWORK",

--- a/pool/irium-stratum/src/delegation.rs
+++ b/pool/irium-stratum/src/delegation.rs
@@ -454,6 +454,7 @@ pub fn pool_identity_json(
     pool_pubkey_hex: &str,
     network_id: u8,
     fee: Option<(u16, [u8; 20])>,
+    proposer_pubkey: Option<[u8; 33]>,
 ) -> serde_json::Value {
     let mut v = serde_json::json!({
         "pool_pubkey": pool_pubkey_hex,
@@ -466,6 +467,12 @@ pub fn pool_identity_json(
         if bps > 0 {
             v["fee_pkh"] = serde_json::Value::String(hex::encode(pkh));
         }
+    }
+    // Stage D v2: advertise the pool's custodial proposer key so a miner's signup
+    // tool can bind it into the delegation (enables real delegated block production,
+    // not just the receipt path). Omitted => legacy receipt-only signup.
+    if let Some(pp) = proposer_pubkey {
+        v["proposer_pubkey"] = serde_json::Value::String(hex::encode(pp));
     }
     v
 }
@@ -4571,10 +4578,22 @@ async fn handle_conn(mut stream: TcpStream, ctx: Arc<ServerCtx>) {
             Some(p) => {
                 // Advertise the pool's configured third-party fee terms (or fee-0
                 // when official / mode off / mainnet).
+                // The pool holds only the proposer PUBKEY (the producer holds the
+                // secret). Advertise it from env when configured; absent => omitted.
+                let proposer_pubkey = std::env::var("IRIUM_POAWX_POOL_PROPOSER_PUBKEY_HEX")
+                    .ok()
+                    .and_then(|s| hex::decode(s.trim()).ok())
+                    .filter(|b| b.len() == 33)
+                    .map(|b| {
+                        let mut o = [0u8; 33];
+                        o.copy_from_slice(&b);
+                        o
+                    });
                 let v = pool_identity_json(
                     &p.key.pubkey_hex(),
                     p.network_id,
                     pool_third_party_fee_terms(),
+                    proposer_pubkey,
                 );
                 respond(&mut stream, 200, "OK", &v).await
             }
@@ -4769,6 +4788,102 @@ mod tests {
     use super::*;
     use k256::ecdsa::signature::hazmat::PrehashSigner;
     use k256::ecdsa::{Signature, SigningKey, VerifyingKey};
+
+    // Step A: /poawx/pool-identity advertises the configured custodial proposer key,
+    // and the pool accepts a delegation that binds it -- over real HTTP against serve().
+    #[tokio::test]
+    async fn step_a_pool_identity_advertises_proposer_and_accepts_bound_delegation() {
+        use std::sync::Arc;
+        let _g = p20_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let dir = std::env::temp_dir().join(format!("stepA_pool_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        std::env::set_var("IRIUM_POAWX_DELEGATE_KEY_PATH", dir.join("delegate.hex"));
+        std::env::set_var("IRIUM_POAWX_DELEGATIONS_PATH", dir.join("delegations.json"));
+        let proposer_sk = SigningKey::from_bytes((&[0x11u8; 32]).into()).unwrap();
+        let proposer_pub = pk33(&proposer_sk);
+        std::env::set_var("IRIUM_POAWX_POOL_PROPOSER_PUBKEY_HEX", hex::encode(proposer_pub));
+
+        let producer = load_producer().map(Arc::new);
+        let prod = producer.clone().expect("producer loads on devnet");
+        let pool_pubkey = prod.key.pubkey();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let bind = format!("127.0.0.1:{port}");
+        {
+            let b = bind.clone();
+            let p = producer.clone();
+            tokio::spawn(async move {
+                let _ = serve(b, p, 2, "http://127.0.0.1:1/".to_string(), "t".to_string()).await;
+            });
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let client = reqwest::Client::new();
+        // 1. identity advertises the proposer key (the Step A pool change).
+        let id: serde_json::Value = client
+            .get(format!("http://{bind}/poawx/pool-identity"))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(
+            id["proposer_pubkey"].as_str().unwrap_or(""),
+            hex::encode(proposer_pub),
+            "pool-identity must advertise the configured proposer_pubkey"
+        );
+        assert_eq!(id["pool_pubkey"].as_str().unwrap_or(""), hex::encode(pool_pubkey));
+
+        // 2. a proposer-bound delegation is accepted.
+        let miner_sk = SigningKey::from_bytes((&[0x22u8; 32]).into()).unwrap();
+        let mut d = Delegation {
+            deleg_version: Delegation::VERSION,
+            network_id: 2,
+            miner_pubkey: pk33(&miner_sk),
+            pool_pubkey,
+            worker_tag: [0u8; 32],
+            expiry_height: 10_000_000,
+            fee_bps: 0,
+            fee_pkh: [0u8; 20],
+            deleg_nonce: [7u8; 32],
+            proposer_pubkey: proposer_pub,
+            delegation_sig: [0u8; 64],
+        };
+        let sig: Signature = miner_sk.sign_prehash(&d.message_hash()).unwrap();
+        d.delegation_sig.copy_from_slice(&sig.to_bytes());
+        assert_eq!(&d.serialize()[162..195], &proposer_pub[..], "proposer at wire offset 162");
+        d.verify_signature().expect("delegation self-verifies");
+        // Acceptance: verify_and_store validates + persists the proposer-bound delegation
+        // (tip/time passed directly; the HTTP path only adds a node tip lookup).
+        let stored = verify_and_store(
+            prod.store.as_ref(),
+            &hex::encode(d.serialize()),
+            "",
+            &hex::encode(d.miner_pkh()),
+            &pool_pubkey,
+            2,
+            100,
+            1_700_000_000,
+            None,
+        )
+        .expect("proposer-bound delegation accepted by verify_and_store");
+        assert_eq!(stored.miner_pkh, hex::encode(d.miner_pkh()), "stored under miner pkh");
+
+        for k in [
+            "IRIUM_NETWORK",
+            "IRIUM_POAWX_DELEGATE_KEY_PATH",
+            "IRIUM_POAWX_DELEGATIONS_PATH",
+            "IRIUM_POAWX_POOL_PROPOSER_PUBKEY_HEX",
+        ] {
+            std::env::remove_var(k);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     fn pk33(sk: &SigningKey) -> [u8; 33] {
         let vk = VerifyingKey::from(sk);
@@ -5247,7 +5362,7 @@ mod tests {
     #[test]
     fn pool_identity_json_shape() {
         let pk = "02".to_string() + &"ab".repeat(32);
-        let v = pool_identity_json(&pk, 1, None);
+        let v = pool_identity_json(&pk, 1, None, None);
         assert_eq!(v["pool_pubkey"], pk);
         assert_eq!(v["network_id"], 1);
         assert_eq!(v["fee_bps"], 0);
@@ -5259,7 +5374,7 @@ mod tests {
         );
         // Third-party identity advertises exact fee terms.
         let fp = [0xFEu8; 20];
-        let vt = pool_identity_json(&pk, 1, Some((200, fp)));
+        let vt = pool_identity_json(&pk, 1, Some((200, fp)), None);
         assert_eq!(vt["fee_bps"], 200);
         assert_eq!(vt["fee_pkh"], hex::encode(fp));
     }

--- a/src/bin/irium-wallet.rs
+++ b/src/bin/irium-wallet.rs
@@ -3379,9 +3379,10 @@ fn signer_material_from_wallet(address: &str) -> Result<(WalletKey, SigningKey),
 /// OFFICIAL pool fee is 0% (`fee_bps == 0`, zero `fee_pkh`). Phase 20 Step 4: a
 /// third-party fee (`fee_bps` in 1..=200 with a non-zero `fee_pkh`) is supported
 /// on non-mainnet networks; the fee terms are bound into the miner's signature.
-fn build_signed_delegation(
+fn build_signed_delegation_with_proposer(
     signing_key: &SigningKey,
     pool_pubkey: [u8; 33],
+    proposer_pubkey: [u8; 33],
     network_id: u8,
     worker: &str,
     expiry_height: u64,
@@ -3431,9 +3432,8 @@ fn build_signed_delegation(
         fee_bps,
         fee_pkh,
         deleg_nonce,
-        // Stage D Step 1: v2 wire field. A real custodial proposer key is wired
-        // into the wallet CLI in a later step; zero placeholder for now.
-        proposer_pubkey: [0u8; 33],
+        // Stage D v2: the pool's custodial proposer key (zero => legacy receipt-only).
+        proposer_pubkey,
         delegation_sig: [0u8; 64],
     };
     let sig: Signature = signing_key
@@ -3441,6 +3441,51 @@ fn build_signed_delegation(
         .map_err(|e| format!("sign delegation: {e}"))?;
     d.delegation_sig.copy_from_slice(&sig.to_bytes());
     Ok(d)
+}
+
+/// Back-compat wrapper: bind a zero proposer key (receipt-path only / legacy tests).
+/// The Stage D v2 signup path calls build_signed_delegation_with_proposer with the
+/// pool's advertised proposer key.
+#[allow(clippy::too_many_arguments)]
+fn build_signed_delegation(
+    signing_key: &SigningKey,
+    pool_pubkey: [u8; 33],
+    network_id: u8,
+    worker: &str,
+    expiry_height: u64,
+    fee_bps: u16,
+    fee_pkh: [u8; 20],
+    deleg_nonce: [u8; 32],
+) -> Result<irium_node_rs::poawx::Delegation, String> {
+    build_signed_delegation_with_proposer(
+        signing_key,
+        pool_pubkey,
+        [0u8; 33],
+        network_id,
+        worker,
+        expiry_height,
+        fee_bps,
+        fee_pkh,
+        deleg_nonce,
+    )
+}
+
+/// Resolve an optional `--proposer-pubkey` hex (66 chars / 33 bytes); None => zero
+/// (legacy / receipt-only). Online mode reads this from /poawx/pool-identity instead.
+fn resolve_proposer_pubkey(hex_opt: &Option<String>) -> Result<[u8; 33], String> {
+    match hex_opt {
+        None => Ok([0u8; 33]),
+        Some(h) => {
+            let b = hex::decode(h.trim())
+                .map_err(|_| "--proposer-pubkey invalid hex".to_string())?;
+            if b.len() != 33 {
+                return Err("--proposer-pubkey must be 33 bytes (66 hex)".to_string());
+            }
+            let mut o = [0u8; 33];
+            o.copy_from_slice(&b);
+            Ok(o)
+        }
+    }
 }
 
 fn next_flag_value(args: &[String], i: &mut usize) -> Result<String, String> {
@@ -3481,6 +3526,9 @@ struct PoawxRegisterArgs {
     third_party_pool: bool,
     /// Phase 20 Step 4: third-party fee recipient (base58 address or 40-hex pkh).
     fee_pkh: Option<String>,
+    /// Stage D v2: optional custodial proposer pubkey to bind (emit-only mode;
+    /// online mode reads it from /poawx/pool-identity).
+    proposer_pubkey_hex: Option<String>,
 }
 
 /// Resolve a `--fee-pkh` argument: a 40-char hex (20-byte) pkh, or a base58 P2PKH
@@ -3517,6 +3565,7 @@ fn parse_poawx_register_args(args: &[String]) -> Result<PoawxRegisterArgs, Strin
         fee_bps: 0,
         third_party_pool: false,
         fee_pkh: None,
+        proposer_pubkey_hex: None,
     };
     let mut i = 1usize;
     while i < args.len() {
@@ -3553,6 +3602,9 @@ fn parse_poawx_register_args(args: &[String]) -> Result<PoawxRegisterArgs, Strin
                 i += 1;
             }
             "--fee-pkh" => a.fee_pkh = Some(next_flag_value(args, &mut i)?),
+            "--proposer-pubkey" => {
+                a.proposer_pubkey_hex = Some(next_flag_value(args, &mut i)?)
+            }
             other => return Err(format!("unknown flag {other}")),
         }
     }
@@ -4766,11 +4818,13 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
         let (pool_pubkey, network_id, addr, worker, expiry, fee_bps, fee_pkh) =
             resolve_emit_only_args(&a)?;
         let (_key, signing_key) = signer_material_from_wallet(&addr)?;
+        let proposer_pubkey = resolve_proposer_pubkey(&a.proposer_pubkey_hex)?;
         let mut nonce = [0u8; 32];
         OsRng.fill_bytes(&mut nonce);
-        let d = build_signed_delegation(
+        let d = build_signed_delegation_with_proposer(
             &signing_key,
             pool_pubkey,
+            proposer_pubkey,
             network_id,
             &worker,
             expiry,
@@ -4865,13 +4919,33 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
     let mut pool_pubkey = [0u8; 33];
     pool_pubkey.copy_from_slice(&pool_pubkey_bytes);
 
+    // Stage D v2: bind the pool's advertised custodial proposer key so the delegation
+    // authorizes real delegated block production. Legacy pools that don't advertise one
+    // => zero proposer (receipt-path only), with a clear note.
+    let proposer_pubkey = match id.get("proposer_pubkey").and_then(|v| v.as_str()) {
+        Some(h) => {
+            let b = hex::decode(h).map_err(|_| "pool proposer_pubkey invalid hex".to_string())?;
+            if b.len() != 33 {
+                return Err("pool proposer_pubkey must be 33 bytes".to_string());
+            }
+            let mut o = [0u8; 33];
+            o.copy_from_slice(&b);
+            o
+        }
+        None => {
+            eprintln!("[register] note: pool did not advertise a proposer_pubkey; binding zero (receipt-path only, not delegated block production)");
+            [0u8; 33]
+        }
+    };
+
     // 2. Sign delegation with the wallet key (in memory only).
     let (_key, signing_key) = signer_material_from_wallet(&addr)?;
     let mut nonce = [0u8; 32];
     OsRng.fill_bytes(&mut nonce);
-    let d = build_signed_delegation(
+    let d = build_signed_delegation_with_proposer(
         &signing_key,
         pool_pubkey,
+        proposer_pubkey,
         network_id,
         &worker,
         expiry,
@@ -27255,6 +27329,22 @@ fn main() {
         }
         "poawx-register" => {
             if let Err(e) = cmd_poawx_register(&args) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+        "delegate-pool" => {
+            // Friendly alias for poawx-register: `delegate-pool <address> --pool <url>
+            // --worker <name> --expiry-height <N> [flags]`. Translates the positional
+            // <address> into --addr and reuses the exact register flow.
+            if args.len() < 2 || args[1].starts_with("--") {
+                eprintln!("usage: irium-wallet delegate-pool <address> --pool <url> --worker <name> --expiry-height <N>");
+                std::process::exit(1);
+            }
+            let mut translated =
+                vec!["poawx-register".to_string(), "--addr".to_string(), args[1].clone()];
+            translated.extend_from_slice(&args[2..]);
+            if let Err(e) = cmd_poawx_register(&translated) {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/src/bin/irium-wallet.rs
+++ b/src/bin/irium-wallet.rs
@@ -3379,6 +3379,24 @@ fn signer_material_from_wallet(address: &str) -> Result<(WalletKey, SigningKey),
 /// OFFICIAL pool fee is 0% (`fee_bps == 0`, zero `fee_pkh`). Phase 20 Step 4: a
 /// third-party fee (`fee_bps` in 1..=200 with a non-zero `fee_pkh`) is supported
 /// on non-mainnet networks; the fee terms are bound into the miner's signature.
+/// Resolve the signing key: prefer the raw secret in IRIUM_POAWX_DELEGATION_SECRET_HEX (set
+/// by the Irium Core app, which derives it from the unlocked wallet and passes it via env to
+/// this sidecar), else load it from the plaintext wallet file for `address`. Lets the app
+/// reuse the delegate-pool / revoke-delegation flows without a shared wallet file.
+fn resolve_signing_key(address: &str) -> Result<(Option<WalletKey>, SigningKey), String> {
+    if let Ok(hex_s) = std::env::var("IRIUM_POAWX_DELEGATION_SECRET_HEX") {
+        let b = hex::decode(hex_s.trim())
+            .map_err(|_| "IRIUM_POAWX_DELEGATION_SECRET_HEX invalid hex".to_string())?;
+        if b.len() != 32 {
+            return Err("IRIUM_POAWX_DELEGATION_SECRET_HEX must be 32 bytes (64 hex)".to_string());
+        }
+        let sk = SigningKey::from_slice(&b).map_err(|e| format!("bad delegation secret: {e}"))?;
+        return Ok((None, sk));
+    }
+    let (k, sk) = signer_material_from_wallet(address)?;
+    Ok((Some(k), sk))
+}
+
 fn build_signed_delegation_with_proposer(
     signing_key: &SigningKey,
     pool_pubkey: [u8; 33],
@@ -4817,7 +4835,7 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
     if a.emit_only {
         let (pool_pubkey, network_id, addr, worker, expiry, fee_bps, fee_pkh) =
             resolve_emit_only_args(&a)?;
-        let (_key, signing_key) = signer_material_from_wallet(&addr)?;
+        let (_key, signing_key) = resolve_signing_key(&addr)?;
         let proposer_pubkey = resolve_proposer_pubkey(&a.proposer_pubkey_hex)?;
         let mut nonce = [0u8; 32];
         OsRng.fill_bytes(&mut nonce);
@@ -4940,7 +4958,7 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
     };
 
     // 2. Sign delegation with the wallet key (in memory only).
-    let (_key, signing_key) = signer_material_from_wallet(&addr)?;
+    let (_key, signing_key) = resolve_signing_key(&addr)?;
     let mut nonce = [0u8; 32];
     OsRng.fill_bytes(&mut nonce);
     let d = build_signed_delegation_with_proposer(
@@ -5024,7 +5042,7 @@ fn cmd_revoke_delegation(args: &[String]) -> Result<(), String> {
     deleg_nonce.copy_from_slice(&nb);
 
     // Load the payout key (the delegation's signer = the revocation authority) and sign.
-    let (_key, signing_key) = signer_material_from_wallet(&addr)?;
+    let (_key, signing_key) = resolve_signing_key(&addr)?;
     let secret: [u8; 32] = signing_key.to_bytes().into();
     let rec = irium_node_rs::poawx::DelegationRevocationV1::build_signed(
         &secret,

--- a/src/bin/irium-wallet.rs
+++ b/src/bin/irium-wallet.rs
@@ -4851,8 +4851,9 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
             "official fee_bps 0".to_string()
         };
         eprintln!(
-            "[emit-only] signed delegation for miner_pkh {} (worker {worker}, expiry {expiry}, {fee_note}); no network used. Send the JSON above to the operator to POST to the loopback-only /poawx/delegation endpoint.",
-            hex::encode(d.miner_pkh())
+            "[emit-only] signed delegation for miner_pkh {} (worker {worker}, expiry {expiry}, deleg_nonce {}, {fee_note}); no network used. Send the JSON above to the operator to POST to the loopback-only /poawx/delegation endpoint. Keep the deleg_nonce -- you need it to revoke later.",
+            hex::encode(d.miner_pkh()),
+            hex::encode(d.deleg_nonce)
         );
         return Ok(());
     }
@@ -4974,11 +4975,77 @@ fn cmd_poawx_register(args: &[String]) -> Result<(), String> {
     let status = resp.status();
     let text = resp.text().unwrap_or_default();
     if status.is_success() {
-        println!("delegation registered (miner_pkh {miner_pkh_hex}, worker {worker}, expiry {expiry}): {text}");
+        println!("delegation registered (miner_pkh {miner_pkh_hex}, worker {worker}, expiry {expiry}, deleg_nonce {}): {text}", hex::encode(nonce));
+        eprintln!("[register] keep this deleg_nonce -- you need it to revoke later: irium-wallet revoke-delegation --addr <addr> --deleg-nonce {} --network-id {network_id}", hex::encode(nonce));
         Ok(())
     } else {
         Err(format!("delegation rejected (HTTP {status}): {text}"))
     }
+}
+
+/// `revoke-delegation`: sign a Stage D DelegationRevocationV1 with the wallet's payout key
+/// to cancel a previously-signed pool delegation. GENERATE AND HAND OFF: revocation is
+/// on-chain only right now (no pool submit endpoint), so this prints the signed 130-byte
+/// revocation hex plus plain guidance; the operator embeds it on-chain, and it takes effect
+/// once included in a block -- not instantly like signup.
+fn cmd_revoke_delegation(args: &[String]) -> Result<(), String> {
+    let mut addr: Option<String> = None;
+    let mut nonce_hex: Option<String> = None;
+    let mut network_id: Option<u8> = None;
+    let mut i = 1usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--addr" => addr = Some(next_flag_value(args, &mut i)?),
+            "--deleg-nonce" => nonce_hex = Some(next_flag_value(args, &mut i)?),
+            "--network-id" => {
+                network_id = Some(
+                    next_flag_value(args, &mut i)?
+                        .parse()
+                        .map_err(|_| "invalid --network-id".to_string())?,
+                )
+            }
+            other => return Err(format!("unknown flag {other}")),
+        }
+    }
+    let addr = addr.ok_or("revoke-delegation requires --addr <address>")?;
+    let network_id = network_id
+        .ok_or("revoke-delegation requires --network-id <id> (must match the delegation's network)")?;
+    if network_id == 0 {
+        return Err("delegation revocation is not available on mainnet (network_id 0)".to_string());
+    }
+    let nonce_hex = nonce_hex.ok_or(
+        "revoke-delegation requires --deleg-nonce <64hex> (the deleg_nonce printed at signup)",
+    )?;
+    let nb = hex::decode(nonce_hex.trim()).map_err(|_| "--deleg-nonce invalid hex".to_string())?;
+    if nb.len() != 32 {
+        return Err("--deleg-nonce must be 32 bytes (64 hex)".to_string());
+    }
+    let mut deleg_nonce = [0u8; 32];
+    deleg_nonce.copy_from_slice(&nb);
+
+    // Load the payout key (the delegation's signer = the revocation authority) and sign.
+    let (_key, signing_key) = signer_material_from_wallet(&addr)?;
+    let secret: [u8; 32] = signing_key.to_bytes().into();
+    let rec = irium_node_rs::poawx::DelegationRevocationV1::build_signed(
+        &secret,
+        network_id,
+        deleg_nonce,
+    )
+    .map_err(|e| format!("build revocation: {e}"))?;
+    rec.validate(network_id)
+        .map_err(|e| format!("self-verify revocation failed before emit: {e}"))?;
+
+    // stdout: ONLY the hex (pipe/save friendly). stderr: plain-language hand-off guidance.
+    println!("{}", hex::encode(rec.serialize()));
+    eprintln!(
+        "[revoke] signed delegation-revocation for address {addr} (deleg_nonce {}).",
+        hex::encode(deleg_nonce)
+    );
+    eprintln!("[revoke] Revocation is ON-CHAIN ONLY right now -- there is no instant pool submit endpoint.");
+    eprintln!("[revoke] Hand the hex above to the pool operator to embed on-chain (IRIUM_POAWX_REVOKE_HEX).");
+    eprintln!("[revoke] It takes effect once included in a block, NOT instantly. After that the network stops");
+    eprintln!("[revoke] paying delegated rewards for this delegation and you fall back to the pool's off-chain fair tracking.");
+    Ok(())
 }
 
 fn sign_target_hash(
@@ -27345,6 +27412,12 @@ fn main() {
                 vec!["poawx-register".to_string(), "--addr".to_string(), args[1].clone()];
             translated.extend_from_slice(&args[2..]);
             if let Err(e) = cmd_poawx_register(&translated) {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+        "revoke-delegation" => {
+            if let Err(e) = cmd_revoke_delegation(&args) {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -14697,6 +14697,39 @@ async fn poawx_finality_vote_post(
 
 /// Phase 21I: loopback-only GET finality votes for a height (hex-encoded canonical
 /// wire bytes, deterministic order). The pool filters by block_hash locally.
+#[derive(serde::Deserialize)]
+struct ProposerStatusQuery {
+    pkh: String,
+}
+
+/// Step F: "am I registered / eligible as a proposer?" Given a payout pkh, report whether it
+/// has an on-chain proposer registration and whether it is currently eligible (past the
+/// freeze depth), plus the eligible-set size. Mirrors D's status pattern; read-only.
+async fn poawx_proposer_status_get(
+    State(state): State<AppState>,
+    Query(q): Query<ProposerStatusQuery>,
+) -> Result<Json<Value>, StatusCode> {
+    let pkh_bytes = hex::decode(q.pkh.trim()).map_err(|_| StatusCode::BAD_REQUEST)?;
+    if pkh_bytes.len() != 20 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let mut pkh = [0u8; 20];
+    pkh.copy_from_slice(&pkh_bytes);
+    let tip = state.status_height_cache.load(Ordering::Relaxed);
+    let guard = state.chain.lock().unwrap_or_else(|e| e.into_inner());
+    let reg = &guard.proposer_registry;
+    let registered = reg.is_registered_pkh(&pkh);
+    let eligible = reg.eligible_pkhs(tip).contains(&pkh);
+    let eligible_count = reg.eligible_count(tip);
+    Ok(Json(json!({
+        "pkh": q.pkh,
+        "tip_height": tip,
+        "registered": registered,
+        "eligible": eligible,
+        "eligible_count": eligible_count,
+    })))
+}
+
 async fn poawx_finality_votes_get(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -19437,6 +19470,7 @@ async fn main() {
         // hard-off, disabled unless the finality gossip gate is configured).
         .route("/poawx/finality-vote", post(poawx_finality_vote_post))
         .route("/poawx/registration", post(poawx_post_registration))
+        .route("/poawx/proposer-status", get(poawx_proposer_status_get))
         .route("/poawx/finality-votes", get(poawx_finality_votes_get))
         .route("/rpc/submit_tx", post(submit_tx))
         // Fix D: pending-tx introspection + per-address pending-spent

--- a/src/poawx_proposer.rs
+++ b/src/poawx_proposer.rs
@@ -349,6 +349,13 @@ impl ProposerEligibilityRegistry {
         self.keys.contains_key(vrf_pubkey)
     }
 
+    /// Step F: whether ANY on-chain-registered proposer key is owned by `pkh` (regardless
+    /// of freeze/eligibility). Used by the proposer-status query so a miner can check by its
+    /// payout pkh without knowing the exact VRF key bytes.
+    pub fn is_registered_pkh(&self, pkh: &[u8; 20]) -> bool {
+        self.keys.values().any(|r| &r.pkh == pkh)
+    }
+
     pub fn len(&self) -> usize {
         self.keys.len()
     }


### PR DESCRIPTION
DO NOT MERGE — opened only to trigger and record a GitHub CI run for visibility. This is a feature branch; it is not intended to merge into main.

## What this contains (node repo, on top of testing tip 62d9275)

Backend tooling for one-time pool-delegation signup so the pool pays a miner PRIMARY rewards directly on-chain to the miner's own address (Stage D C1 custodial-proposer model). Built and tested against isolated harnesses; nothing deployed or activated.

- Step A (aa1f3db): pool /poawx/pool-identity advertises the custodial proposer_pubkey; irium-wallet binds it into the delegation (build_signed_delegation_with_proposer), online fetch + --proposer-pubkey flag; new delegate-pool <address> alias.
- Step B (0c5bfd3): irium-wallet revoke-delegation (signs DelegationRevocationV1, generate-and-hand-off; revocation is on-chain-only). Surfaces deleg_nonce at signup.
- Step C enabler (028a6b9): env-secret signing path (IRIUM_POAWX_DELEGATION_SECRET_HEX) so the Irium Core app can reuse the CLI without a shared wallet file.
- Step D (1b9cb7d): pool GET /poawx/delegation-status?miner_pkh=... (delegated? worker, expiry, deleg_nonce).
- Step F (cbcac68): node GET /poawx/proposer-status?pkh=... (registered/eligible/count) + ProposerEligibilityRegistry::is_registered_pkh.
- Docs (375675b): docs/miner-direct-pool-rewards.md, the miner-facing guide.

The app-side commands and minimal UI stubs (Steps C/D/E/F) live in the separate irium-core repo and are not part of this PR.

## Tested (isolated harnesses)

Pool suite 111/0; delegation-status proven over HTTP; delegate-pool and revoke-delegation proven via the real CLI; proposer-status proven end-to-end against an isolated node that mined PoAW-X blocks. Local CI-equivalent on this branch: cargo test --all -- --test-threads=1 = 2467 passed / 0 failed; cargo audit = 2 pre-existing allowed advisories.

## Deferred (flagged, not guessed)

The live app-to-pool round-trip and UI visual polish, pending the pool infrastructure track standing up a real pool and a display for interactive testing.

Generated with Claude Code
