### PR TITLE
Stage D D1-D5 + C4 carrier-stripping (gated off, CI only, do not merge)

### DIFF
--- a/docs/STAGE_D_FINAL_READINESS.md
+++ b/docs/STAGE_D_FINAL_READINESS.md
@@ -1,0 +1,116 @@
+# Stage D / multi-role pool production - final readiness summary
+
+Scope: everything built and proven across this effort, exactly what is ready, and
+the one thing that still requires a real Bitaxe hardware test before mainnet
+activation could ever be responsibly considered.
+
+Status posture (unchanged throughout): everything is behind the
+`stage_d_production_active` gate (hard mainnet-off, default-off), isolated-rig /
+devnet only. NOTHING is merged to main, deployed to the live pool, pushed to
+origin, or activated. No mainnet activation height has been set or discussed.
+
+Branches (local on the VPS):
+- `testing-codes-before-merging` @ `a1a6675` - C4 harness + docs (base for the below).
+- `stage-d/live-proposer-wiring` @ `7e74720` (base testing `04c97cb`) - D1-D5 + carrier fix.
+
+---
+
+## 1. What is READY (built, tested, and proven)
+
+### A. Fail-safe multi-role coinbase notify (prior work, `04c97cb`)
+The reshaped multi-role notify path was fallible and dropped ASIC sessions on any
+coinbase-build error (the reproduced cause of the 3 live breaks). Now infallible:
+on any build error it falls back to the self-pay coinbase and keeps the session.
+Success path byte-identical; zero live-mainnet change.
+
+### B. C4 sustained-load heap validation - DONE, definitive
+The one non-code ASIC-notify risk (heap fragmentation over sustained load) was
+validated with a faithful host harness: the real ESP-IDF v5.5.3 multi_heap + TLSF
+allocator (-m32) + the real ESP-Miner stratum RX/parse pattern + real cJSON +
+genuine captured multi-role frames.
+- Accelerated: 30,000,000 jobs at a thin 40 KB margin -> 0 alloc failures, 0
+  esp_restart; free stayed one contiguous block start to finish. Zero fragmentation.
+- Real-cadence: full 6-hour TCP soak (16,042 jobs) -> identical, 0 failures.
+- Verdict: the sustained-fragmentation hypothesis is refuted. The only residual was
+  per-notify transient peak footprint (worst on the carrier-laden frame).
+- QEMU-ESP32 was honestly ruled out (no WiFi emulation, no ASIC/I2C stack,
+  idealized PSRAM) rather than presented as a definitive emulation.
+
+### C. Carrier-stripping mitigation - DONE (closes the C4 residual)
+The multi-role coinbase fed the raw template header-relay carriers even to
+small-buffer ASIC firmware (the self-pay path already stripped them). Fixed:
+`session_template_coinbase_extras` strips carriers per-session for small-buffer
+firmware on the multi-role path too. Result: ASIC multi-role notify 4699B/9113B ->
+669B; true peak heap footprint ~19KB/~37KB -> ~2.5KB (well below the ~18KB target),
+serviceable down to an 8 KB internal heap. Regression-tested. Non-small-buffer
+firmware and the STRATUM_CARRIERS=off kill-switch are unchanged.
+
+### D. Stage-D infrastructure (gated, inert)
+- Settable mainnet delegation gate (`MAINNET_POAWX_DELEGATION_ACTIVATION_HEIGHT =
+  None`); behavior byte-identical today.
+- Byte-parity proposer-registration mirror (PRG1) proven against the node.
+- Option A ext selection wired (prefers the collected bundle when the gate is on).
+
+### E. D1-D5 delegated direct-payout (proposer-VRF off) - DONE and PROVEN
+- D1: the pool holds a custodial proposer secret and advertises its pubkey.
+- D2: PRG1 proposer-registration section in the pool ext mirror, full-ext parity
+  vs the node (node deserializes + round-trips the pool ext byte-for-byte).
+- D3: gated proposer-registration emission (off by default; forward-prep).
+- D5: the delegated mode-1 receipt pays the miner directly (worker_pkh = miner);
+  proven byte-parity with the node.
+- End-to-end (in-process): the node's real connect_block ACCEPTS a delegated
+  all-gates block with proposer-VRF off, paying the miner directly on-chain.
+- End-to-end (LIVE isolated devnet): the real pool binary produced delegated blocks
+  over stratum that the real node ACCEPTED via submit_block_extended
+  (source=pool_stratum_native_rewardable, 3 blocks, tip advanced), paying the miner
+  directly - with a v2 delegation and no proposer_assignment (proposer-VRF off).
+  Isolated storage/ports; mainnet and rig untouched.
+
+### Test status (zero regressions across all of the above)
+- Pool suite: 119/0. Node lib: 862/0. Production builds clean.
+
+---
+
+## 2. What is DEFERRED (explicitly, by decision - not blockers to the above)
+
+- D4 - full proposer-VRF custodial mode: the pool would have to produce a real
+  RFC-9381 ECVRF proposer proof, but a VRF proof cannot be mirrored (it must be
+  computed with the secret) and the pool production path has no ECVRF prover. This
+  needs an architecture decision (add an ECVRF prover to the pool / a shared proving
+  crate / change proposer custody) and is deferred (Option 1 chosen: ship the
+  direct-payout path with proposer-VRF off). Same ECVRF-prover limit also blocks the
+  pool from self-producing contributor true-VRF proofs, so the live demo runs the
+  gate set that does not require a pool-side prover.
+- Distinct per-role live participants: the live devnet used the devnet-only single-
+  miner synthetic role source, so all role payouts resolve to the one miner. Distinct
+  COMPUTE/VERIFY/SUPPORT participants need the live role-collection path (separate
+  work); the in-process node test already proves distinct-participant acceptance.
+
+---
+
+## 3. The ONE thing that still requires REAL BITAXE HARDWARE
+
+Before the `stage_d_production_active` gate could EVER be flipped on for a real
+ASIC-facing pool or mainnet, a real (or faithfully device-emulated) Bitaxe-class
+ASIC must:
+1. connect to a pool serving the reshaped multi-role coinbase (carrier-stripped),
+2. assemble coinbase = cb1 + extranonce + cb2, compute the merkle root, and
+3. produce accepted shares against that coinbase, sustained, with well-formed
+   phase20 exts throughout (so it exercises the multi-role path, not the self-pay
+   fallback), and stay heap-stable.
+
+Why the host validation is not sufficient on its own: it faithfully reproduces the
+allocator algorithm and the alloc/free pattern (fragmentation is an allocator
+property, and both soaks refute it), but it is not silicon - it omits concurrent
+WiFi/ASIC/task internal-heap pressure and cache/timing. The rig-green result was
+false-green three times; only real hardware closes that gap.
+
+What has changed since those three breaks (why a hardware test is now much more
+likely to pass):
+- the notify path no longer drops the session on any build error (fail-safe);
+- sustained heap fragmentation is refuted by 30M-job + 6h soaks;
+- the ASIC-facing multi-role notify is now carrier-stripped (669B, ~2.5KB peak),
+  removing the size/footprint variable that correlated with the breaks.
+
+Only after that hardware test explicitly passes and is separately approved could a
+mainnet activation height even be discussed. Until then the gate stays off.

--- a/docs/d4_spike_finding.md
+++ b/docs/d4_spike_finding.md
@@ -1,0 +1,116 @@
+# D4 spike finding: the pool cannot self-produce a proposer VRF proof (architectural blocker)
+
+Status: SPIKE COMPLETE. The plan (docs/m3_stage_d_proposer_production_plan.md)
+called for spiking D4 FIRST because it was the largest unknown. It is now
+resolved, and the answer is a genuine architectural blocker that changes the rest
+of the plan. This document records the exact requirement, the blocker, the scope
+that IS achievable now, and the decision the blocker forces.
+
+## What a pool-submitted block must carry (traced in the node)
+
+For the node to accept the pool's custodial/delegated proposer, each PoAW-X
+receipt in a `submit_block_extended` block must carry, inside its `phase20_ext`:
+
+1. `proposer_assignment: Some(ProposerAssignmentV1 { round: u32, proof:
+   AssignmentProofV2 })` (node `src/poawx.rs:632`, magic `PRP1`).
+   `AssignmentProofV2` (node `src/poawx_candidate.rs:633`, 273-byte wire) is a
+   real **RFC-9381 ECVRF proof over secp256k1**. For a proposer proof:
+   `role_id = ROLE_PROPOSER (0)`, `ticket_digest = [0;32]`, `seed =
+   expected_epoch_seed(height, prev_hash, previous)`, `assignment_public_key =`
+   the custodial proposer VRF key, `solver_pkh = hash160(assignment_public_key)`,
+   and a VALID `vrf_proof` / `vrf_output` produced by proving with the proposer
+   SECRET. `round` is chosen by running local VRF sortition
+   (`priority(vrf_output) < threshold(eligible_count, round)`).
+2. A v2 `delegation` whose `proposer_pubkey == assignment_public_key`,
+   `pool_pubkey ==` the pool signer, `miner_pkh() == worker_pkh` (miner payout).
+
+The node validates this in `validate_block_proposer` (`src/chain.rs:1350`), which
+runs `pa.proof.validate(net, height)?` - a full ECVRF verify - plus role, seed,
+ticket, solver-pkh, delegation-binding, eligibility, sortition and round-timing
+checks. The registration must additionally be frozen in the registry (announced
+with a valid recent sybil anchor, activated off the FIFO queue, aged >=
+`FREEZE_DEPTH = 16` blocks, within expiry). Reference implementation the pool
+must reproduce: `build_delegated_poawx_block_with_proposer`
+(`src/poawx_mining_harness.rs:580`), where the proof is built by
+`AssignmentProofV2::prove_self_solver(proposer_secret, ...)`.
+
+## The blocker
+
+A VRF proof is not a wire format that can be "mirrored" - it must be **computed**
+with the proposer secret using the ECVRF prover. The pool intentionally does not
+have that prover:
+
+- `AssignmentProofV2Mirror` (pool `src/delegation.rs:1327`) is explicitly ser/de
+  only: "mirrors the 273-byte wire byte-for-byte ... (no `vrf_fun` dependency
+  here)". It cannot generate a valid proof.
+- `irium-node-rs` is a **`[dev-dependencies]`** of the pool only
+  (`pool/irium-stratum/Cargo.toml:34`); every `irium_node_rs::` use in `src/` is
+  under `#[cfg(test)]`. Production code cannot call the node's prover.
+
+So the pool's production path **cannot produce a valid custodial proposer
+`AssignmentProofV2`** today. This is the true reason the custodial-proposer live
+production was deferred - and the spike has now made it precise.
+
+## What IS achievable now (proposer-VRF enforcement OFF)
+
+`validate_block_proposer` and `validate_block_proposer_registrations` are called
+by `connect_block` **only when `proposer_vrf_enforced(height)`** (`chain.rs:941`),
+which is mainnet-hard-off and env-gated on non-mainnet. With it OFF:
+
+- The pool CAN produce a **delegated block that pays the miner directly** (the
+  Stage-D user-facing goal): the delegation-triangle check
+  (`validate_poawx_block_receipts`, gated by `poawx_delegation_active`, not
+  proposer-VRF) still verifies `d.verify_signature()`, `d.miner_pkh() ==
+  worker_pkh`, `worker_pubkey == pool_pubkey`. This needs **no ECVRF prover**.
+- The PRG1 registration section (D2), the custodial secret load (D1), the
+  registration emission (D3), and the delegation binding (D5) are all
+  implementable and testable without the prover.
+
+So the achievable slice is: **D1 + D2 + D3 + D5 with proposer-VRF enforcement
+OFF** => the node accepts a pool-produced delegated block paying the miner
+directly on-chain. **D4 (the per-block proposer VRF proof, required only when
+proposer-VRF is enforced) is the sole blocked item.**
+
+## The decision the blocker forces (for the FULL custodial-proposer mode)
+
+To make the pool act as a sybil-registered proposer under proposer-VRF
+enforcement, one of these must be chosen (a real architecture decision, not
+wiring):
+
+- **A. Add an ECVRF prover to the pool's production dependencies.** Add `vrf_fun`
+  (or the minimal secp256k1 ECVRF used by the node) as a real dependency and give
+  `AssignmentProofV2Mirror` a `prove` path byte-compatible with the node. Highest
+  fidelity risk (must match the node's ECVRF byte-for-byte) and enlarges the live
+  pool's crypto surface. Would need its own parity + adversarial review before any
+  ASIC-facing use.
+- **B. Promote a minimal proving crate.** Factor the node's proposer-proof
+  builder into a small, audited crate depended on by both node and pool (avoids
+  hand-mirroring ECVRF, but is a workspace/dependency change).
+- **C. Miner-produced proposer proof.** Keep the prover in `irium-miner` (which
+  already has it) and have the miner produce the proposer `AssignmentProofV2` for
+  the pool's custodial key - but the miner does not hold the custodial secret, so
+  this needs a custody/protocol change (e.g. the pool signs, or a different
+  proposer-custody model). Largest protocol change.
+- **D. Run the custodial-proposer pool with proposer-VRF enforcement OFF.** Ship
+  the direct-payout delegated mode (D1/D2/D3/D5) without proposer-VRF, and treat
+  proposer-VRF-enforced custodial proposing as a separate later milestone. Lowest
+  risk; delivers the user-facing "pay the miner directly" goal now; does not give
+  the pool a sybil-registered VRF proposer identity.
+
+Recommendation: **do not add crypto to the live pool binary unilaterally.** Land
+D1/D2/D3/D5 gated off (option D's building blocks), and take the A/B/C decision
+explicitly before building an ECVRF prover into a real ASIC-facing pool. Every one
+of A/B/C is gated behind the same `stage_d_production_active` inert gate and the
+unresolved real-ASIC notify test (Milestone 4) regardless.
+
+## This pass
+
+- D2 landed: `Phase20ReceiptExtMirror.proposer_registrations` + PRG1 serialize in
+  the exact node position + full-ext parity test
+  (`d2_proposer_registration_section_full_ext_parity_with_node`): the pool builds a
+  full ext carrying PRG1 and the node deserializes+round-trips it byte-for-byte.
+- D1/D3/D5 code and the direct-payout end-to-end (proposer-VRF off) are ready to
+  build on top; deferred pending the A/B/C/D decision above so the work is not
+  redone against the chosen proposer-custody architecture.
+- D4 (ECVRF proposer proof) blocked on that decision. Nothing here is merged,
+  deployed, activated, or on the live pool/mainnet.

--- a/docs/d5_direct_payout_proof.md
+++ b/docs/d5_direct_payout_proof.md
@@ -1,0 +1,58 @@
+# D5 direct-payout end-to-end proof (proposer-VRF off)
+
+Goal (user's Option 1): prove the node accepts a pool-produced delegated block
+that pays the miner directly on-chain, with proposer-VRF enforcement OFF - the
+mode the pool can run today with no ECVRF prover (see d4_spike_finding.md).
+
+## How the proof is constructed (in-process, deterministic)
+
+`stage_d_delegated_direct_payout_proposer_vrf_off_connect_block_pays_miner`
+(src/chain.rs) runs the node's REAL `connect_block` on a delegated (mode-1)
+all-gates block, with proposer-VRF enforcement OFF, and asserts acceptance +
+direct miner payout. It is the pool's exact scenario:
+
+- Every all-gates check is ON (tickets, candidate-set, assignment-proof,
+  puzzle-work, finality, committed-admission, true-VRF, penalty, anti-domination,
+  multi-role reward, delegation) EXCEPT proposer-VRF (`IRIUM_POAWX_PROPOSER_VRF_*`
+  unset => `proposer_vrf_enforced(2) == false`, asserted in the test).
+- The block carries a miner-signed v2 `Delegation` (payout key signs; binds
+  proposer_pubkey + pool_pubkey + payout) and NO proposer-VRF assignment
+  (`proposer_ctx = None` => `phase20_ext.proposer_assignment == None`, asserted).
+- `connect_block` ACCEPTS it and the tip advances.
+- The on-chain coinbase: PRIMARY output pays the MINER's payout pkh directly;
+  the role outputs pay the pool delegate (which did the role work). Miner != pool
+  delegate ("no central wallet").
+
+## Why this is a faithful end-to-end proof of the POOL's path
+
+The proof uses the node's real `connect_block` (not a stub) on a block that is
+byte-equivalent to what the pool produces, and that equivalence is separately
+proven by the pool parity tests:
+- `phase18b3_build_mode1_receipt_and_root_parity`: the pool's mode-1 receipt pays
+  the miner (`worker_pkh == miner`, `worker_pubkey == pool delegate`, delegation
+  embedded) and its receipts-root equals the node's `irx1_root_from_block_receipts`.
+- `phase18c_native_notify_split_matches_validation_coinbase_mode1`: the pool's
+  multi-role notify coinbase (cb1+extranonce+cb2) reconstructs to the exact
+  validation coinbase.
+- D2 `d2_proposer_registration_section_full_ext_parity_with_node`: the pool's ext
+  (incl. any PRG1 registration) round-trips through the node byte-for-byte.
+
+So: the node accepts a delegated direct-payout block with proposer-VRF off (this
+proof), and the pool produces byte-identical receipts/coinbase (parity proofs) =>
+the node accepts the pool's delegated direct-payout block and the miner is paid
+directly. No ECVRF prover is involved anywhere.
+
+## What this is and is not
+
+- IS: a deterministic in-process proof against the node's real consensus
+  validation, exercising the pool's exact production scenario. Repeatable, not
+  environment-fragile.
+- IS NOT: a live TCP devnet run of the pool binary end-to-end (node+pool+miner
+  over sockets). The in-process proof + byte-parity proofs together establish the
+  same fact without the fragility of a full socket standup. If a live-socket
+  demonstration is wanted as additional evidence, it is a separate follow-up.
+- The full proposer-VRF-enforced custodial mode (D4) remains blocked on the
+  ECVRF-prover architecture decision and is explicitly deferred.
+
+All work is behind `stage_d_production_active` / the emit gate, mainnet hard-off.
+Not merged, not deployed, no activation.

--- a/docs/d5_live_devnet_proof.md
+++ b/docs/d5_live_devnet_proof.md
@@ -1,0 +1,61 @@
+# D5 LIVE isolated-devnet direct-payout proof (proposer-VRF off)
+
+The in-process proof (docs/d5_direct_payout_proof.md) established the semantics
+against the node's real connect_block. This document records the LIVE end-to-end
+run: the actual pool binary produces a delegated block over stratum and the actual
+node accepts it via submit_block_extended, paying the miner directly on-chain.
+
+Harness: pool/irium-stratum/tools/devnet_directpay_demo.sh (isolated storage +
+ports; mainnet :38300 and rig :38500 untouched; torn down at end).
+
+## Topology (all four real binaries, built from this branch)
+
+- iriumd (node): devnet, isolated IRIUM_DATA_DIR/BLOCKS_DIR/STATE_DIR, gates ON
+  EXCEPT proposer-VRF (IRIUM_POAWX_PROPOSER_VRF_* unset => proposer_vrf_enforced
+  == false), delegation active. Isolation asserted from the node log
+  ("Using blocks dir: .../devnet-directpay/blocks") - never ~/.irium.
+- irium-stratum (pool): IRIUM_STRATUM_POAWX=1, NATIVE_REWARDABLE_ENABLED=1,
+  IRIUM_POAWX_STAGE_D_PRODUCTION=1, delegation server on loopback, isolated key/
+  store paths.
+- irium-wallet: signs the miner's v2 delegation (poawx-register) with an isolated
+  key (IRIUM_POAWX_DELEGATION_SECRET_HEX), never a mainnet/wallet key.
+- irium-miner: stratum client mining the pool's jobs.
+
+## What was proven LIVE
+
+1. D1 live: the pool loaded its custodial proposer secret and advertised the
+   derived pubkey - pool log: "custodial proposer pubkey advertised (Stage D,
+   network_id=2)"; /poawx/pool-identity returns proposer_pubkey.
+2. Delegation signup live: irium-wallet poawx-register signed a v2 delegation
+   binding the advertised proposer pubkey + pool pubkey + miner payout, POSTed it,
+   and the pool stored it - "delegation registered (miner_pkh ..., worker rig1,
+   ... status active)".
+3. Pool produces the mode-1 multi-role coinbase live: session adapter
+   native_rewardable_reserved; producer trace "build_mode1 OK ...
+   delegation_present=true", "session_receipts BUILT count=1
+   phase20_ext_present=true". The notify coinbase carries 4 role P2PKH outputs +
+   the irx1 OP_RETURN commitment.
+4. Node ACCEPTS the pool-produced block: node log "[submit_block_extended]
+   accepted height=3 ... source=pool_stratum_native_rewardable". 3 blocks
+   accepted; tip advanced.
+5. Miner paid directly on-chain: accepted block height=3 has
+   miner_address = the miner's address, poawx_receipts[0].delegation present
+   (deleg_ver=02), and the miner payout pkh appears in the coinbase. The pool
+   delegate pubkey is distinct from the miner (no central wallet).
+6. Proposer-VRF genuinely off: the accepted receipt carries NO proposer_assignment
+   (PRP1 section absent) and the node accepted it anyway - exactly the pool's
+   no-ECVRF-prover mode.
+
+## Notes / honest scope
+
+- Single-miner synthetic role source (IRIUM_POAWX_SYNTHETIC_ROLE_CLAIMS=1,
+  testnet/devnet-only): all role solver pkhs resolve to the one miner, so the
+  miner receives PRIMARY + roles. Distinct per-role participants would require the
+  live role-collection path (separate work). The direct-payout claim (miner paid
+  on-chain by a pool-produced, node-accepted delegated block, proposer-VRF off) is
+  fully demonstrated.
+- The gate set enables every PoAW-X gate that does not require the pool to hold an
+  ECVRF prover; proposer-VRF (and the full custodial-proposer VRF mode, D4) stays
+  off/deferred per the ECVRF-prover decision (docs/d4_spike_finding.md).
+- Isolated + torn down; nothing merged, deployed, or activated; live pool/mainnet
+  untouched.

--- a/pool/irium-stratum/src/delegation.rs
+++ b/pool/irium-stratum/src/delegation.rs
@@ -1966,6 +1966,59 @@ pub fn build_pool_proposer_registration_section(
     })
 }
 
+/// D3 emission gate: whether the pool should attach its custodial proposer
+/// registration (PRG1) to produced blocks. Non-mainnet only, default OFF
+/// (`IRIUM_POAWX_PROPOSER_REGISTER=1`). Deliberately INDEPENDENT of
+/// `stage_d_production_active` so the delegated DIRECT-PAYOUT path can run without
+/// emitting any registration (keeping the produced ext byte-identical to the
+/// no-registration case). Under proposer-VRF-off the node parses but does not
+/// validate the section (forward-prep for the proposer-VRF-enforced mode; the full
+/// "emit until frozen, then stop" freeze-tracking via /poawx/proposer-status is
+/// deferred with the ECVRF custodial-proposer decision - see docs/d4_spike_finding.md).
+pub fn proposer_registration_emit_enabled() -> bool {
+    if network_id_from_env() == 0 {
+        return false; // mainnet hard-off
+    }
+    env::var("IRIUM_POAWX_PROPOSER_REGISTER")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false)
+}
+
+/// D3: build the custodial proposer registration section to attach to a produced
+/// block, anchored to the parent block (anchor_height = height-1, anchor_hash =
+/// prev_hash). Returns None when emission is disabled or on any build error
+/// (fail-open: the block is still produced without it). `required_bits` from
+/// `IRIUM_POAWX_PROPOSER_SYBIL_BITS` (default 0; the node only validates the sybil
+/// PoW under proposer-VRF enforcement, which is off in direct-payout mode).
+pub fn maybe_build_proposer_registration(
+    proposer_secret: &[u8; 32],
+    network_id: u8,
+    height: u64,
+    prev_hash: &[u8; 32],
+) -> Option<ProposerRegistrationSectionMirror> {
+    if !proposer_registration_emit_enabled() {
+        return None;
+    }
+    let anchor_height = height.saturating_sub(1);
+    let required_bits = env::var("IRIUM_POAWX_PROPOSER_SYBIL_BITS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(0);
+    match build_pool_proposer_registration_section(
+        proposer_secret,
+        network_id,
+        anchor_height,
+        prev_hash,
+        required_bits,
+    ) {
+        Ok(section) => Some(section),
+        Err(e) => {
+            warn!("[poawx-deleg] proposer registration build failed: {e}");
+            None
+        }
+    }
+}
+
 /// Whether the gated SYNTHETIC role-claim builder is enabled. Testnet/devnet-only
 /// (`IRIUM_POAWX_SYNTHETIC_ROLE_CLAIMS=1`), mainnet hard-off, disabled by default.
 /// This is for production-wiring validation; it is NOT the live hidden-precommit
@@ -4700,6 +4753,15 @@ pub struct PoawxProducer {
     /// Step 6B: shared role precommit/reveal store (loopback-fed); read by the
     /// receipt-producer path to build collected Phase 20 exts.
     pub role_store: Arc<RoleProtocolStore>,
+    /// D1 (Stage D): the pool's custodial proposer secret, loaded ONLY when the
+    /// Stage-D production gate is configured and the network is non-mainnet. `None`
+    /// => today's behavior (no custodial proposer key; delegation signup advertises
+    /// no proposer_pubkey). Used to advertise the matching proposer pubkey (so a
+    /// miner's delegation binds a key the pool actually holds) and by D3 to sign the
+    /// on-chain proposer registration. NOT used to VRF-prove a block proposer - the
+    /// pool has no ECVRF prover (see docs/d4_spike_finding.md); direct-payout mode
+    /// runs with proposer-VRF enforcement off.
+    pub proposer_secret: Option<[u8; 32]>,
 }
 
 /// Load the producer (delegate key + delegation store). Returns None on mainnet
@@ -4728,11 +4790,46 @@ pub fn load_producer() -> Option<PoawxProducer> {
         "[poawx-deleg] pool_pubkey={} network_id={network_id}",
         key.pubkey_hex()
     );
+    // D1: when the Stage-D production gate is configured (non-mainnet only; mainnet
+    // already returned None above), load or generate the custodial proposer secret
+    // and advertise its derived pubkey so a miner's delegation signup binds a key the
+    // pool actually holds. Fail-open to None on any error (delegation direct-payout
+    // still works; only the proposer-registration/binding forward-prep is skipped).
+    let proposer_secret = if stage_d_production_active(0) {
+        match load_or_generate_proposer_secret(&proposer_key_path(), network_id != 0) {
+            Ok(sec) => {
+                match pubkey_from_secret(&sec) {
+                    Ok(pk) => {
+                        // Only set when not already provided, so an explicit operator
+                        // override of the advertised pubkey is preserved.
+                        if env::var("IRIUM_POAWX_POOL_PROPOSER_PUBKEY_HEX").is_err() {
+                            env::set_var(
+                                "IRIUM_POAWX_POOL_PROPOSER_PUBKEY_HEX",
+                                hex::encode(pk),
+                            );
+                        }
+                        info!(
+                            "[poawx-deleg] custodial proposer pubkey advertised (Stage D, network_id={network_id})"
+                        );
+                    }
+                    Err(e) => warn!("[poawx-deleg] proposer pubkey derive failed: {e}"),
+                }
+                Some(sec)
+            }
+            Err(e) => {
+                warn!("[poawx-deleg] custodial proposer key unavailable: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
     Some(PoawxProducer {
         store,
         key: Arc::new(key),
         network_id,
         role_store: Arc::new(RoleProtocolStore::new()),
+        proposer_secret,
     })
 }
 
@@ -6757,6 +6854,53 @@ mod tests {
         let node_none =
             irium_node_rs::poawx::Phase20ReceiptExt::deserialize(&ext_none.serialize()).unwrap();
         assert!(node_none.proposer_registrations.is_none());
+    }
+
+    #[test]
+    fn d3_proposer_registration_emit_gate_and_section_validity() {
+        // D3: the pool attaches its custodial proposer registration only when the
+        // emit gate is on (default OFF, so the direct-payout path stays clean), it is
+        // mainnet-hard-off regardless of the flag, and the produced section is a valid
+        // node-parseable PRG1 anchored to the parent block.
+        let _g = p20_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        let secret = [0x33u8; 32];
+        let net = 2u8;
+        let prev = [0x77u8; 32];
+
+        // Gate OFF (default): nothing emitted.
+        std::env::remove_var("IRIUM_POAWX_PROPOSER_REGISTER");
+        assert!(
+            maybe_build_proposer_registration(&secret, net, 100, &prev).is_none(),
+            "no registration emitted when the gate is off (direct-payout stays clean)"
+        );
+
+        // Gate ON: a valid section anchored to the parent (height-1), node-parseable.
+        std::env::set_var("IRIUM_POAWX_PROPOSER_REGISTER", "1");
+        std::env::set_var("IRIUM_POAWX_PROPOSER_SYBIL_BITS", "0");
+        let section = maybe_build_proposer_registration(&secret, net, 100, &prev)
+            .expect("registration emitted when the gate is on");
+        assert_eq!(section.announces.len(), 1);
+        assert!(section.activations.is_empty());
+        // anchor_height is bytes [33..41] LE of the record wire; must be parent = 99.
+        let rec_bytes = section.announces[0].serialize();
+        let anchor_height =
+            u64::from_le_bytes(rec_bytes[33..41].try_into().expect("anchor_height slice"));
+        assert_eq!(anchor_height, 99, "registration anchored to the parent height");
+        // The node accepts the pool-built record byte-for-byte.
+        irium_node_rs::poawx::ProposerRegistrationV1::deserialize(&rec_bytes)
+            .expect("node deserializes the pool-built registration record");
+
+        // Mainnet hard-off regardless of the flag.
+        std::env::set_var("IRIUM_NETWORK", "mainnet");
+        assert!(
+            !proposer_registration_emit_enabled(),
+            "proposer registration emission is mainnet-hard-off"
+        );
+
+        std::env::remove_var("IRIUM_POAWX_PROPOSER_REGISTER");
+        std::env::remove_var("IRIUM_POAWX_PROPOSER_SYBIL_BITS");
+        std::env::remove_var("IRIUM_NETWORK");
     }
 
     #[test]

--- a/pool/irium-stratum/src/delegation.rs
+++ b/pool/irium-stratum/src/delegation.rs
@@ -1477,6 +1477,12 @@ pub struct Phase20ReceiptExtMirror {
     /// Phase 22D: optional per-role true-VRF assignment proofs [compute, verify,
     /// support] (trailing AVR2 section; None => byte-identical to pre-22D).
     pub role_assignment_v2: Option<[AssignmentProofV2Mirror; 3]>,
+    /// D2 (Stage D deferred): optional proposer-registration section (trailing PRG1;
+    /// None => byte-identical to pre-D2). Serialized in the EXACT node position: after
+    /// AVR2 and before the node's RVK1 section (the pool never emits RVK1). Attached by
+    /// the gated emit-until-frozen path (D3) so the custodial proposer key is registered
+    /// on-chain. Node reads it order-tolerantly by PRG1 magic (poawx.rs deserialize loop).
+    pub proposer_registrations: Option<ProposerRegistrationSectionMirror>,
 }
 
 impl Phase20ReceiptExtMirror {
@@ -1510,6 +1516,7 @@ impl Phase20ReceiptExtMirror {
                     || self.finality_proof.is_some()
                     || self.committed_admission.is_some()
                     || self.role_assignment_v2.is_some()
+                    || self.proposer_registrations.is_some()
                 {
                     out.push(0);
                 }
@@ -1558,6 +1565,14 @@ impl Phase20ReceiptExtMirror {
             for pr in proofs.iter() {
                 out.extend_from_slice(&pr.serialize());
             }
+        }
+        // D2 trailing PRG1 proposer-registration section (present-only). Emitted in
+        // the node's exact position (after AVR2, before the node's RVK1). The pool
+        // never emits RVK1, so PRG1 is the pool mirror's last section. reg.serialize()
+        // already writes the PRG1 magic + counts + records, byte-identical to the node
+        // encoder (poawx.rs Phase20ReceiptExt::serialize).
+        if let Some(reg) = &self.proposer_registrations {
+            out.extend_from_slice(&reg.serialize());
         }
         out
     }
@@ -3566,6 +3581,7 @@ pub fn build_synthetic_phase20_ext(
         finality_proof,
         committed_admission,
         role_assignment_v2,
+        proposer_registrations: None,
     })
 }
 
@@ -4097,6 +4113,7 @@ pub fn build_collected_bundle_ext(
         finality_proof: None,
         committed_admission: None,
         role_assignment_v2: Some([assigns[0].clone(), assigns[1].clone(), assigns[2].clone()]),
+        proposer_registrations: None,
     })
 }
 
@@ -4212,6 +4229,7 @@ pub fn build_collected_phase20_ext(
         finality_proof,
         committed_admission,
         role_assignment_v2,
+        proposer_registrations: None,
     })
 }
 
@@ -6050,6 +6068,7 @@ mod tests {
             finality_proof: None,
             committed_admission: None,
             role_assignment_v2: None,
+            proposer_registrations: None,
         };
         let node_ext = irium_node_rs::poawx::Phase20ReceiptExt {
             role_reward: node_rr,
@@ -6470,6 +6489,7 @@ mod tests {
             finality_proof: None,
             committed_admission: None,
             role_assignment_v2: None,
+            proposer_registrations: None,
         };
         attach_true_vrf_section(&mut pe, mp);
         let ne = irium_node_rs::poawx::Phase20ReceiptExt {
@@ -6657,6 +6677,86 @@ mod tests {
             expect,
             "pool PRG1 section framing is byte-identical to the node ext encoder layout"
         );
+    }
+
+    #[test]
+    fn d2_proposer_registration_section_full_ext_parity_with_node() {
+        // D2: the PRG1 proposer-registration section must serialize at the EXACT node
+        // position inside the FULL Phase20 ext (trailing, after AVR2, preceded by the
+        // `0` precommit flag when precommit is None), and the node must deserialize the
+        // pool-produced full-ext bytes back with the section intact. The node reads
+        // trailing sections order-tolerantly by magic, so emitting PRG1 alone - without
+        // the intervening FRAUD/PRP1/RVK1 sections the pool never produces - is valid.
+        let net = 2u8;
+        let anchor_hash = [0x44u8; 32];
+        let secret = [0x22u8; 32];
+        let section =
+            build_pool_proposer_registration_section(&secret, net, 5, &anchor_hash, 0).unwrap();
+
+        let mk_pool = |role: u8| PoawxRoleClaimMirror {
+            role_id: role,
+            lane_id: LANE_GPU_PARALLEL,
+            solver_pkh: [role; 20],
+            nonce: [role; 32],
+            secret: [role.wrapping_add(1); 32],
+            claim_digest: [role.wrapping_add(2); 32],
+            commitment_hash: None,
+        };
+        let base = |proposer_registrations| Phase20ReceiptExtMirror {
+            role_reward: RoleRewardMirror {
+                compute_contributor_pkh: [1u8; 20],
+                verify_contributor_pkh: [2u8; 20],
+                support_contributor_pkh: [3u8; 20],
+            },
+            compute_claim: mk_pool(1),
+            verify_claim: mk_pool(2),
+            support_claim: mk_pool(3),
+            fee_bps: 0,
+            fee_pkh: [0u8; 20],
+            precommit_root: None,
+            role_ticket_proofs: None,
+            role_dominance_weights: None,
+            candidate_set: None,
+            role_puzzle_proofs: None,
+            finality_proof: None,
+            committed_admission: None,
+            role_assignment_v2: None,
+            proposer_registrations,
+        };
+        let ext_none = base(None);
+        let ext_reg = base(Some(section.clone()));
+
+        // (1) Exact position: the ONLY difference from the no-section ext is the `0`
+        // precommit flag followed by the PRG1 section bytes, appended last.
+        let mut expect = ext_none.serialize();
+        expect.push(0u8);
+        expect.extend_from_slice(&section.serialize());
+        assert_eq!(
+            ext_reg.serialize(),
+            expect,
+            "PRG1 must be the trailing section, preceded by the 0 precommit flag"
+        );
+
+        // (2) The node deserializes the pool's full-ext bytes, recovers the section,
+        // and re-serializes to the identical bytes (full fidelity through the node).
+        let node_round =
+            irium_node_rs::poawx::Phase20ReceiptExt::deserialize(&ext_reg.serialize())
+                .expect("node must deserialize the pool ext carrying PRG1");
+        assert!(
+            node_round.proposer_registrations.is_some(),
+            "node recovered the PRG1 registration section"
+        );
+        assert_eq!(
+            node_round.serialize(),
+            ext_reg.serialize(),
+            "node round-trips the pool ext (incl. PRG1) byte-for-byte"
+        );
+
+        // (3) Gate-off byte-identity: with no section the ext is byte-identical to a
+        // pre-D2 ext (no trailing bytes) and carries no registration.
+        let node_none =
+            irium_node_rs::poawx::Phase20ReceiptExt::deserialize(&ext_none.serialize()).unwrap();
+        assert!(node_none.proposer_registrations.is_none());
     }
 
     #[test]
@@ -7654,6 +7754,7 @@ mod tests {
             finality_proof: None,
             committed_admission: None,
             role_assignment_v2: None,
+            proposer_registrations: None,
         };
         // node lib reads the pool DOM1 weights back identically (wire parity).
         let node_ext =
@@ -9327,6 +9428,7 @@ mod tests {
                 finality_proof: None,
                 committed_admission: None,
                 role_assignment_v2: None,
+                proposer_registrations: None,
             };
         let fpkh = [0x7Fu8; 20];
         // Pre-6A (no precommit_root): fee parses correctly.
@@ -9531,6 +9633,7 @@ mod tests {
             finality_proof: None,
             committed_admission: None,
             role_assignment_v2: None,
+            proposer_registrations: None,
         };
         let node_ext =
             irium_node_rs::poawx::Phase20ReceiptExt::deserialize(&ext.serialize()).unwrap();

--- a/pool/irium-stratum/src/stratum.rs
+++ b/pool/irium-stratum/src/stratum.rs
@@ -1512,7 +1512,27 @@ fn build_session_poawx_receipts(
                         ctx.block_height,
                         fee,
                         &job.prev_hash,
-                    );
+                    )
+                    .map(|mut ext| {
+                        // D3: attach the pool custodial proposer registration (PRG1)
+                        // when emission is enabled (IRIUM_POAWX_PROPOSER_REGISTER=1,
+                        // default OFF) and a custodial secret is held. Forward-prep for
+                        // the proposer-VRF-enforced mode; inert/unvalidated under
+                        // proposer-VRF off. OFF by default => byte-identical to today.
+                        if let Some(sec) = producer.proposer_secret.as_ref() {
+                            if let Some(section) =
+                                crate::delegation::maybe_build_proposer_registration(
+                                    sec,
+                                    producer.network_id,
+                                    ctx.block_height,
+                                    &job.prev_hash,
+                                )
+                            {
+                                ext.proposer_registrations = Some(section);
+                            }
+                        }
+                        ext
+                    });
                     if trace {
                         info!(
                             "[poawx-trace] phase20 M3 stage_d gate ON block_h={} bundle={}",
@@ -7370,6 +7390,7 @@ mod tests {
             key: std::sync::Arc::new(delegate),
             network_id: 2,
             role_store: std::sync::Arc::new(crate::delegation::RoleProtocolStore::new()),
+            proposer_secret: None,
         });
         config.poawx_producer = Some(producer);
 

--- a/pool/irium-stratum/src/stratum.rs
+++ b/pool/irium-stratum/src/stratum.rs
@@ -1723,7 +1723,7 @@ fn build_canonical_job_snapshot(
         auxpow_mode,
         irium_header80,
         irium_coinbase_hex,
-        coinbase_extra_outputs: job.template_coinbase_extra_outputs.clone(),
+        coinbase_extra_outputs: session_template_coinbase_extras(job, session),
         poawx_pending_receipts: build_session_poawx_receipts(job, session, config, &pkh),
         poawx_reg_activations: job.poawx_reg_activations.clone(),
         poawx_reg_announces: job.poawx_reg_announces.clone(),
@@ -2206,6 +2206,28 @@ fn session_coinbase_extras<'a>(job: &'a Job, session: &SessionState) -> &'a [(u6
         &[]
     } else {
         &job.coinbase_extras
+    }
+}
+
+/// C4 carrier-stripping mitigation: the MULTI-ROLE (native rewardable / Stage-D)
+/// coinbase carrier extras, filtered per-session EXACTLY like session_coinbase_extras
+/// filters the self-pay extras. Small-buffer ASIC firmware gets EMPTY carriers so the
+/// reshaped multi-role mining.notify stays small (role payouts + irx1 only, ~2.5KB)
+/// instead of the carrier-laden ~4.7KB..~9KB worst case that inflates the firmware's
+/// transient JSON/parse footprint (see docs/c4_sustained_heap_results.md). Non-small-
+/// buffer keeps the raw template extras (backward-compat). STRATUM_CARRIERS=off already
+/// empties template_coinbase_extra_outputs at to_job, so the kill-switch still wins.
+/// Returns an owned Vec (not a borrow) because the empty case has no backing slice.
+fn session_template_coinbase_extras(job: &Job, session: &SessionState) -> Vec<(u64, Vec<u8>)> {
+    if session
+        .user_agent
+        .as_deref()
+        .map(is_small_buffer_firmware)
+        .unwrap_or(false)
+    {
+        Vec::new()
+    } else {
+        job.template_coinbase_extra_outputs.clone()
     }
 }
 
@@ -5358,6 +5380,128 @@ mod tests {
             mined, validation_cb,
             "mode-0 split must still match validation"
         );
+    }
+
+    #[test]
+    fn c4_multirole_notify_strips_carriers_for_small_buffer_asic() {
+        // C4 mitigation regression: the reshaped multi-role coinbase must NOT carry the
+        // header-relay carrier outputs for small-buffer ASIC firmware, so its
+        // mining.notify stays small (role payouts + irx1 only) instead of the
+        // carrier-laden ~4.7KB..~9KB worst case that inflates the firmware's transient
+        // parse footprint (docs/c4_sustained_heap_results.md). Non-small-buffer firmware
+        // keeps the carriers (backward-compat). This must never regress.
+        // Enable multi-role production so build_native_rewardable_coinbase takes the
+        // 4-output multi-role branch (node_phase20_production_active must be true).
+        let _g = crate::delegation::p20_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        std::env::set_var("IRIUM_POAWX_MULTI_ROLE_REWARD_ACTIVATION_HEIGHT", "1");
+        std::env::set_var("IRIUM_POAWX_FAIRNESS_MATRIX_ACTIVATION_HEIGHT", "1");
+        let mut config = test_config(MinerFamilyMode::Asic);
+        config.adapter_mode = AdapterMode::NativeRewardableOnly;
+        config.native_rewardable_enabled = true;
+
+        // A job whose template carries a large (~2 KB) header-relay carrier output.
+        let mut job = native_test_job();
+        let carrier = vec![0xCAu8; 2000]; // distinctive 2 KB carrier script
+        job.template_coinbase_extra_outputs = vec![(0u64, carrier.clone())];
+
+        // A valid role-reward phase20_ext so build_native_rewardable_coinbase takes the
+        // multi-role (4 role outputs + carriers + irx1) branch, not the single-payout
+        // fallback (role_reward_pkhs_from_ext_hex must parse the ext).
+        let mk_claim = |role: u8| crate::delegation::PoawxRoleClaimMirror {
+            role_id: role,
+            lane_id: crate::delegation::LANE_GPU_PARALLEL,
+            solver_pkh: [role; 20],
+            nonce: [role; 32],
+            secret: [role.wrapping_add(1); 32],
+            claim_digest: [role.wrapping_add(2); 32],
+            commitment_hash: None,
+        };
+        let role_ext_hex = hex::encode(
+            crate::delegation::Phase20ReceiptExtMirror {
+                role_reward: crate::delegation::RoleRewardMirror {
+                    compute_contributor_pkh: [0xA1; 20],
+                    verify_contributor_pkh: [0xB2; 20],
+                    support_contributor_pkh: [0xC3; 20],
+                },
+                compute_claim: mk_claim(1),
+                verify_claim: mk_claim(2),
+                support_claim: mk_claim(3),
+                fee_bps: 0,
+                fee_pkh: [0u8; 20],
+                precommit_root: None,
+                role_ticket_proofs: None,
+                role_dominance_weights: None,
+                candidate_set: None,
+                role_puzzle_proofs: None,
+                finality_proof: None,
+                committed_admission: None,
+                role_assignment_v2: None,
+                proposer_registrations: None,
+            }
+            .serialize(),
+        );
+        let with_mode1 = |snap: &mut CanonicalJobSnapshot| {
+            snap.poawx_pending_receipts = vec![PoawxPendingReceipt {
+                height: snap.height,
+                lane: "A".to_string(),
+                worker_pkh: hex::encode([0x11u8; 20]),
+                solution: "0011223344556677".to_string(),
+                commitment_nonce: "cd".repeat(32),
+                worker_pubkey: hex::encode([0x02u8; 33]),
+                worker_sig: "11".repeat(64),
+                delegation: String::new(),
+                phase20_ext: role_ext_hex.clone(),
+            }];
+        };
+
+        // Small-buffer ASIC session (bitaxe): carriers MUST be stripped.
+        let mut asic = test_session(AdapterKind::NativeRewardableReserved);
+        asic.user_agent = Some("bitaxe/2.14.1 (esp-miner bm1370)".to_string());
+        let mut snap_asic = build_canonical_job_snapshot(&job, &asic, &config).unwrap();
+        assert!(
+            snap_asic.coinbase_extra_outputs.is_empty(),
+            "small-buffer ASIC multi-role coinbase MUST strip header-relay carriers"
+        );
+        with_mode1(&mut snap_asic);
+        let (cb1a, cb2a) = native_rewardable_notify_split(&snap_asic).unwrap();
+        assert!(
+            !cb1a.windows(carrier.len()).any(|w| w == &carrier[..])
+                && !cb2a.windows(carrier.len()).any(|w| w == &carrier[..]),
+            "stripped ASIC multi-role notify coinbase must NOT contain the carrier bytes"
+        );
+        let asic_len = cb1a.len() + cb2a.len();
+
+        // Non-small-buffer session (cgminer/large-buffer): carriers INCLUDED (unchanged).
+        let mut big = test_session(AdapterKind::NativeRewardableReserved);
+        big.user_agent = Some("cgminer/4.11.1".to_string());
+        let mut snap_big = build_canonical_job_snapshot(&job, &big, &config).unwrap();
+        assert_eq!(
+            snap_big.coinbase_extra_outputs,
+            vec![(0u64, carrier.clone())],
+            "non-small-buffer multi-role coinbase keeps the template carriers"
+        );
+        with_mode1(&mut snap_big);
+        let (cb1b, cb2b) = native_rewardable_notify_split(&snap_big).unwrap();
+        assert!(
+            cb2b.windows(carrier.len()).any(|w| w == &carrier[..]),
+            "non-small-buffer multi-role notify coinbase carries the carrier bytes"
+        );
+        let big_len = cb1b.len() + cb2b.len();
+
+        // The mitigation strictly shrinks the ASIC frame by ~the carrier size.
+        assert!(
+            asic_len + carrier.len() <= big_len,
+            "stripping removes ~carrier bytes: asic_coinbase={} big_coinbase={}",
+            asic_len,
+            big_len
+        );
+
+        std::env::remove_var("IRIUM_NETWORK");
+        std::env::remove_var("IRIUM_POAWX_MULTI_ROLE_REWARD_ACTIVATION_HEIGHT");
+        std::env::remove_var("IRIUM_POAWX_FAIRNESS_MATRIX_ACTIVATION_HEIGHT");
     }
 
     fn sample_submit_request() -> SubmitRequest {

--- a/pool/irium-stratum/tools/devnet_directpay_demo.sh
+++ b/pool/irium-stratum/tools/devnet_directpay_demo.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Live isolated-devnet direct-payout demo: node + pool + delegated miner, with
+# proposer-VRF enforcement OFF. Proves the pool produces a block the node accepts
+# via submit_block_extended, paying the miner directly on-chain. ISOLATED storage
+# + ports; mainnet (:38300) and rig (:38500) untouched; torn down at end.
+set -u
+D=/home/irium/tmp/d15-wt
+NODE=$D/target/release/iriumd
+POOL=$D/pool/irium-stratum/target/release/irium-stratum
+MINER=$D/target/release/irium-miner
+WALLET=$D/target/release/irium-wallet
+WIF2HEX=/home/irium/tmp/wif2hex/target/release/wif2hex
+ROOT=/home/irium/tmp/devnet-directpay
+RPC=42111; STATUS=42108; P2P=42110; STRAT=42133; DELEG=42140
+TOK=dp-token
+rm -rf "$ROOT"; mkdir -p "$ROOT/data" "$ROOT/blocks" "$ROOT/state"
+NLOG="$ROOT/node.log"; PLOG="$ROOT/pool.log"; MLOG="$ROOT/miner.log"; RLOG="$ROOT/register.log"
+
+cleanup() { for f in "$ROOT"/node.pid "$ROOT"/pool.pid "$ROOT"/miner.pid; do [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null; done; }
+trap cleanup EXIT
+
+# PoAW-X gates that do NOT require the pool to hold an ECVRF prover; proposer-VRF OFF.
+GATE=(
+  IRIUM_NETWORK=devnet
+  IRIUM_POAWX_MODE=active IRIUM_POAWX_ACTIVATION_HEIGHT=1
+  IRIUM_POAWX_PUZZLE_DIFFICULTY_BITS=4 IRIUM_POAWX_PUZZLE_BITS=4
+  IRIUM_POAWX_MULTI_ROLE_REWARD_ACTIVATION_HEIGHT=1 IRIUM_POAWX_FAIRNESS_MATRIX_ACTIVATION_HEIGHT=1
+  IRIUM_POAWX_DELEGATION_ACTIVATION_HEIGHT=1
+  # proposer-VRF intentionally UNSET => proposer_vrf_enforced == false
+)
+
+echo "############ STAGE 1: node up (isolated, proposer-VRF OFF, delegation active) ############"
+# cwd MUST be the repo so the node finds ./bootstrap/trust (anchor allowlist).
+( cd "$D" && env "${GATE[@]}" \
+  IRIUM_DATA_DIR="$ROOT/data" IRIUM_BLOCKS_DIR="$ROOT/blocks" IRIUM_STATE_DIR="$ROOT/state" \
+  IRIUM_WALLET_FILE="$ROOT/wallet.json" \
+  IRIUM_NODE_HOST=127.0.0.1 IRIUM_NODE_PORT=$RPC \
+  IRIUM_STATUS_HOST=127.0.0.1 IRIUM_STATUS_PORT=$STATUS \
+  IRIUM_P2P_BIND=127.0.0.1:$P2P IRIUM_RPC_TOKEN=$TOK \
+  "$NODE" >"$NLOG" 2>&1 ) &
+NPID=$!; echo "$NPID" > "$ROOT/node.pid"
+B="http://127.0.0.1:$RPC"; AUTH="Authorization: Bearer $TOK"
+for i in $(seq 1 50); do grep -qiE "blocks dir|listening|rpc.*(bound|listen)" "$NLOG" && break; sleep 0.5; done
+if ! grep -q "$ROOT/blocks" "$NLOG"; then echo "[FATAL] node storage NOT isolated - aborting"; grep -iE "blocks|data.dir|\.irium" "$NLOG" | head; exit 9; fi
+echo "node pid=$NPID isolated OK"
+
+echo "############ isolated wallet -> miner identity (addr + secret) ############"
+curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' -d '{"passphrase":"dptest123"}' "$B/wallet/create" >/dev/null 2>&1
+curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' -d '{"passphrase":"dptest123"}' "$B/wallet/unlock" >/dev/null 2>&1
+MINER_ADDR=$(curl -s -H "$AUTH" "$B/wallet/receive" 2>/dev/null | grep -oE '"address"[: ]*"[^"]+"' | head -1 | sed -E 's/.*"address"[: ]*"([^"]+)".*/\1/')
+WIF=$(curl -s -H "$AUTH" "$B/wallet/export_wif?address=$MINER_ADDR" 2>/dev/null | grep -oE '"wif"[: ]*"[^"]+"' | head -1 | sed -E 's/.*"wif"[: ]*"([^"]+)".*/\1/')
+MINER_SECRET=$("$WIF2HEX" "$WIF" 2>/dev/null)
+if [ -z "$MINER_ADDR" ] || [ ${#MINER_SECRET} -ne 64 ]; then echo "[FATAL] miner identity failed addr=$MINER_ADDR seclen=${#MINER_SECRET}"; exit 1; fi
+echo "miner addr=$MINER_ADDR secret6=${MINER_SECRET:0:6}..."
+
+echo "############ STAGE 1b: pool up (stage_d ON, native_rewardable ON, delegation server) ############"
+( cd "$D" && env "${GATE[@]}" \
+  IRIUM_RPC_BASE="$B" IRIUM_RPC_TOKEN=$TOK \
+  STRATUM_BIND=127.0.0.1:$STRAT \
+  IRIUM_STRATUM_POAWX=1 IRIUM_STRATUM_NATIVE_REWARDABLE_ENABLED=1 \
+  IRIUM_POAWX_STAGE_D_PRODUCTION=1 IRIUM_POAWX_SYNTHETIC_ROLE_CLAIMS=1 \
+  IRIUM_POAWX_PRODUCER_TRACE=1 \
+  STRATUM_DEFAULT_DIFF=0.0001 IRIUM_STRATUM_VARDIFF_ENABLED=0 \
+  IRIUM_POAWX_DELEGATION_BIND=127.0.0.1:$DELEG \
+  IRIUM_POAWX_DELEGATE_KEY_PATH="$ROOT/pool_delegate.hex" \
+  IRIUM_POAWX_PROPOSER_KEY_FILE="$ROOT/pool_proposer.hex" \
+  IRIUM_POAWX_DELEGATIONS_PATH="$ROOT/pool_delegations.json" \
+  "$POOL" >"$PLOG" 2>&1 ) &
+PPID=$!; echo "$PPID" > "$ROOT/pool.pid"
+DB="http://127.0.0.1:$DELEG"
+sleep 5
+echo "--- pool startup tail ---"; tail -10 "$PLOG"
+echo "--- /poawx/pool-identity (D1: expect proposer_pubkey advertised) ---"
+POOLID=$(curl -s "$DB/poawx/pool-identity"); echo "$POOLID"
+echo "$POOLID" | grep -q proposer_pubkey && echo "[OK] D1 advertises proposer_pubkey" || echo "[WARN] no proposer_pubkey advertised"
+
+echo "############ STAGE 2: register miner delegation with the pool ############"
+env "${GATE[@]}" IRIUM_POAWX_DELEGATION_SECRET_HEX="$MINER_SECRET" \
+  "$WALLET" poawx-register --pool "$DB" --addr "$MINER_ADDR" --worker rig1 --expiry-height 1000000 --fee-bps 0 >"$RLOG" 2>&1
+echo "--- register result ---"; tail -15 "$RLOG"
+echo "--- /poawx/delegation-status?pkh (delegation stored?) ---"
+curl -s "$DB/poawx/delegation-status"; echo
+
+echo "############ STAGE 3: delegated miner mines the pool jobs ############"
+env "${GATE[@]}" \
+  IRIUM_STRATUM_URL="127.0.0.1:$STRAT" \
+  IRIUM_STRATUM_USER="$MINER_ADDR.rig1" IRIUM_STRATUM_PASS=x \
+  "$MINER" >"$MLOG" 2>&1 &
+MPID=$!; echo "$MPID" > "$ROOT/miner.pid"
+echo "miner pid=$MPID mining (up to 150s, stop at first accepted block)..."
+BEST=0
+for i in $(seq 1 50); do
+  sleep 3
+  H=$(curl -s -H "$AUTH" "$B/rpc/getblocktemplate" 2>/dev/null | grep -oE '"height"[: ]*[0-9]+' | grep -oE '[0-9]+' | head -1); H=${H:-1}
+  [ $((H-1)) -gt $BEST ] && BEST=$((H-1))
+  [ "$BEST" -ge 1 ] && { echo "block accepted -> tip=$BEST at ~$((i*3))s"; break; }
+done
+kill $MPID 2>/dev/null; rm -f "$ROOT/miner.pid"
+
+echo "############ RESULTS ############"
+echo "--- pool: mode-1 / multi-role / submit evidence ---"
+grep -iE "mode-1|multi-role|stage_d|submit_block_extended|accepted|proposer|delegation|reject|error" "$PLOG" | tail -20
+echo "--- miner: stratum evidence ---"
+grep -iE "stratum|subscribe|notify|share|submit|accepted|reject|error" "$MLOG" | tail -15
+echo "--- node: block acceptance ---"
+grep -iE "submit_block_extended|accepted|connect_block|height|reject" "$NLOG" | tail -15
+echo "--- chain tip + coinbase payout check ---"
+TIP=$(curl -s -H "$AUTH" "$B/rpc/getblocktemplate" 2>/dev/null | grep -oE '"height"[: ]*[0-9]+' | grep -oE '[0-9]+' | head -1); TIP=$((${TIP:-1}-1))
+echo "chain tip height: $TIP (miner addr $MINER_ADDR should own the PRIMARY coinbase output)"
+if [ "$TIP" -ge 1 ]; then curl -s -H "$AUTH" "$B/rpc/block?height=$TIP" 2>/dev/null | head -c 1200; echo; fi
+echo "############ DONE (teardown on exit) ############"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -11516,6 +11516,178 @@ mod tests {
     }
 
     #[test]
+    fn stage_d_delegated_direct_payout_proposer_vrf_off_connect_block_pays_miner() {
+        // D5 end-to-end (the pool's actual Stage-D scenario): a DELEGATED (mode-1)
+        // all-gates block that carries NO proposer-VRF assignment (proposer_ctx = None)
+        // is accepted by the full connect_block when proposer-VRF enforcement is OFF -
+        // exactly what the pool can produce today (it has no ECVRF prover; see
+        // docs/d4_spike_finding.md). The coinbase PRIMARY still pays the MINER's payout
+        // pkh directly on-chain (delegation triangle only; no central wallet). This is
+        // the direct-payout proof for Option 1: user-facing goal delivered without any
+        // prover. All the OTHER all-gates checks stay ON, so this is the full block
+        // minus proposer-VRF.
+        use crate::poawx_admission::global_admission_cache;
+        use crate::poawx_committed_admission::seed_components_from_block;
+        use crate::poawx_mining_harness::{
+            build_delegated_poawx_block_with_proposer, build_solo_poawx_block_with_parent,
+        };
+        let _g = chain_poawx_env_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        let gates = [
+            ("IRIUM_POAWX_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_MODE", "active"),
+            ("IRIUM_POAWX_PUZZLE_DIFFICULTY_BITS", "1"),
+            ("IRIUM_POAWX_PUZZLE_BITS", "1"),
+            ("IRIUM_POAWX_MULTI_ROLE_REWARD_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_FAIRNESS_MATRIX_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ANTI_DOMINATION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ANTI_DOMINATION_REQUIRED", "1"),
+            ("IRIUM_POAWX_CANDIDATE_SET_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_CANDIDATE_SET_REQUIRED", "1"),
+            ("IRIUM_POAWX_ASSIGNMENT_PROOF_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ASSIGNMENT_PROOF_REQUIRED", "1"),
+            ("IRIUM_POAWX_CANDIDATE_ADMISSION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_CANDIDATE_ADMISSION_REQUIRED", "1"),
+            ("IRIUM_POAWX_PUZZLE_WORK_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PUZZLE_WORK_REQUIRED", "1"),
+            ("IRIUM_POAWX_FINALITY_COMMITTEE_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_FINALITY_COMMITTEE_REQUIRED", "1"),
+            ("IRIUM_POAWX_FINALITY_THRESHOLD_NUM", "1"),
+            ("IRIUM_POAWX_FINALITY_THRESHOLD_DEN", "1"),
+            ("IRIUM_POAWX_COMMITTED_ADMISSION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_COMMITTED_ADMISSION_REQUIRED", "1"),
+            ("IRIUM_POAWX_TRUE_VRF_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_TRUE_VRF_REQUIRED", "1"),
+            ("IRIUM_POAWX_MULTISOURCE_SEED_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_HIDDEN_PRECOMMIT_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_TICKETS_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_TICKETS_REQUIRED", "1"),
+            ("IRIUM_POAWX_TICKET_SYBIL_BITS", "4"),
+            ("IRIUM_POAWX_PENALTY_STATE_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PENALTY_STATE_REQUIRED", "1"),
+            // proposer-VRF NOT set => proposer_vrf_enforced(h) == false (the pool's mode).
+            ("IRIUM_POAWX_DELEGATION_ACTIVATION_HEIGHT", "1"),
+        ];
+        for (k, v) in gates {
+            std::env::set_var(k, v);
+        }
+        assert!(
+            !crate::poawx_proposer::proposer_vrf_enforced(2),
+            "this test runs with proposer-VRF enforcement OFF (the pool's no-prover mode)"
+        );
+
+        let skf = |s: &[u8; 32]| k256::ecdsa::SigningKey::from_bytes(s.into()).unwrap();
+
+        let locked = load_locked_genesis().expect("locked genesis");
+        let genesis = block_from_locked(&locked).expect("genesis block");
+        let genesis_hash = genesis.header.hash_for_height(0);
+        let mut st = base_chain(None);
+        let net = crate::activation::network_id_byte();
+        let cache = global_admission_cache();
+
+        // ---- h1: solo block ----
+        let solo_secret = [0x4Du8; 32];
+        let pc1 = seed_components_from_block(st.chain.last());
+        let bits1 = st.target_for_height(1).bits;
+        let p1 = build_solo_poawx_block_with_parent(
+            &solo_secret, net, 1, genesis_hash, None, bits1, genesis.header.time + 1, 1, pc1,
+        )
+        .expect("build h1");
+        cache.clear();
+        cache.set_tip(1);
+        for adm in &p1.admissions {
+            let _ = cache.ingest_bytes(adm);
+        }
+        let h1_hash = p1.block_hash;
+        st.connect_block(p1.block).expect("connect h1");
+
+        // ---- keys: pool delegate (signs + does role work) and the MINER payout key ----
+        let delegate_secret = [0xB2u8; 32];
+        let payout_secret = [0xC3u8; 32];
+        let custodial_pubkey = pubkey33(&skf(&[0xA1u8; 32])); // advertised proposer key (unenforced here)
+        let delegate_pubkey = pubkey33(&skf(&delegate_secret));
+        let payout_pubkey = pubkey33(&skf(&payout_secret));
+        let payout_pkh = pkh_of(&skf(&payout_secret));
+        let delegate_pkh = pkh_of(&skf(&delegate_secret));
+
+        // ---- miner-signed Delegation v2 (payout key signs; binds proposer+pool+payout) ----
+        let mut d = crate::poawx::Delegation {
+            deleg_version: 2,
+            network_id: net,
+            miner_pubkey: payout_pubkey,
+            pool_pubkey: delegate_pubkey,
+            worker_tag: [0u8; 32],
+            expiry_height: 1_000_000,
+            fee_bps: 0,
+            fee_pkh: [0u8; 20],
+            deleg_nonce: [0x5Du8; 32],
+            proposer_pubkey: custodial_pubkey,
+            delegation_sig: [0u8; 64],
+        };
+        {
+            use k256::ecdsa::signature::hazmat::PrehashSigner;
+            let sig: k256::ecdsa::Signature =
+                skf(&payout_secret).sign_prehash(&d.message_hash()).unwrap();
+            d.delegation_sig.copy_from_slice(&sig.to_bytes());
+        }
+        d.verify_signature().expect("delegation self-verifies");
+
+        // ---- h2: DELEGATED block, NO proposer assignment (proposer_ctx = None) ----
+        let pc2 = seed_components_from_block(st.chain.last());
+        let bits2 = st.target_for_height(2).bits;
+        let p2 = build_delegated_poawx_block_with_proposer(
+            &delegate_secret, d.clone(), net, 2, h1_hash, Some(genesis_hash), bits2,
+            genesis.header.time + 2, 1, pc2, &st.dominance, None, None, None, vec![],
+        )
+        .expect("build delegated h2 (no proposer proof)");
+
+        let r = &p2.block.poawx_receipts.as_ref().unwrap()[0];
+        assert!(r.delegation.is_some(), "h2 receipt is delegated");
+        assert_eq!(r.worker_pkh, payout_pkh, "receipt worker_pkh == miner payout pkh");
+        assert_ne!(r.worker_pkh, delegate_pkh, "receipt worker_pkh != delegate pkh");
+        assert!(
+            r.phase20_ext
+                .as_ref()
+                .and_then(|e| e.proposer_assignment.as_ref())
+                .is_none(),
+            "no proposer-VRF assignment is carried (proposer-VRF off)"
+        );
+
+        cache.clear();
+        cache.set_tip(2);
+        for adm in &p2.admissions {
+            let _ = cache.ingest_bytes(adm);
+        }
+        let coinbase = p2.block.transactions[0].clone();
+        st.connect_block(p2.block)
+            .expect("connect_block accepts the delegated block with proposer-VRF off");
+        assert_eq!(st.tip_height(), 2, "tip advanced to the delegated block");
+
+        // ---- decode the on-chain coinbase: PRIMARY -> miner, roles -> delegate ----
+        let primary_script = crate::tx::p2pkh_script(&payout_pkh);
+        let delegate_script = crate::tx::p2pkh_script(&delegate_pkh);
+        assert_eq!(
+            coinbase.outputs[1].script_pubkey, primary_script,
+            "PRIMARY coinbase output pays the miner payout pkh directly on-chain"
+        );
+        assert!(coinbase.outputs[1].value > 0, "PRIMARY output has value");
+        for i in 2..=4usize {
+            assert_eq!(
+                coinbase.outputs[i].script_pubkey, delegate_script,
+                "role output {i} pays the pool delegate (it did the role work)"
+            );
+        }
+        assert_ne!(payout_pkh, delegate_pkh, "no central wallet: miner != delegate");
+
+        for (k, _) in gates {
+            std::env::remove_var(k);
+        }
+        std::env::remove_var("IRIUM_NETWORK");
+    }
+
+    #[test]
     fn phase4_multi_participant_distinct_role_payouts_connect_block() {
         // Role-attribution Phase 4 final proof: with the contributor-role binding rule
         // ACTIVE, a full all-gates block whose COMPUTE/VERIFY/SUPPORT roles are performed by


### PR DESCRIPTION
Opened to run CI on stage-d/live-proposer-wiring. NOT for merge in this pass.

Contents (all behind stage_d_production_active, hard mainnet-off, gated off; isolated-rig/devnet only; nothing deployed or activated):
- D2: PRG1 proposer-registration in the pool ext mirror, full-ext byte-parity with the node.
- D1: pool holds a custodial proposer secret and advertises its pubkey (gated, non-mainnet).
- D3: gated proposer-registration emission (off by default).
- D5: delegated mode-1 receipt pays the miner directly; proven in-process (node connect_block) and live on an isolated devnet (real pool binary -> submit_block_extended accepted, miner paid, proposer-VRF off).
- D4 finding: the pool has no ECVRF prover; full proposer-VRF custodial mode deferred.
- C4 carrier-stripping mitigation: multi-role ASIC notify carrier-stripped (669B, ~2.5KB peak footprint); regression-tested.

Local suites: pool 119/0, node lib 862/0. See docs/STAGE_D_FINAL_READINESS.md.
Do not merge to main.
