### PR TITLE
feat(poawx): role-bundle collection channel (R1-R4) + height-2 dominance-weight fix (capability-only, inert on mainnet)

### DIFF
--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -14593,6 +14593,34 @@ fn role_bundle_bridge_guard(addr: &SocketAddr) -> Result<(), StatusCode> {
 /// whose puzzle solution cannot verify against the builder's challenge, and it fails
 /// silently at assembly time. Shipping the other parameters without it would invite
 /// exactly that failure.
+/// DEV/TEST-ONLY: return the pool's full, validated collected role bundles for the next
+/// height so a genuinely SEPARATE proposer process can assemble a block from them (the
+/// R1-R4 collection channel exercised end-to-end with real processes). Loopback-guarded
+/// and refused on mainnet (network_id == 0).
+async fn poawx_get_collected_bundles(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+) -> Result<Json<Value>, StatusCode> {
+    role_bundle_bridge_guard(&addr)?;
+    if irium_node_rs::activation::network_id_byte() == 0 {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    let height = {
+        let g = match state.chain.try_lock() {
+            Ok(g) => g,
+            Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
+        };
+        g.tip_height().saturating_add(1)
+    };
+    let pool = irium_node_rs::poawx_role_bundle::global_role_bundle_pool();
+    let bundles: Vec<Value> = pool
+        .collected_for_height(height)
+        .iter()
+        .filter_map(|b| serde_json::from_str::<Value>(&b.to_json()).ok())
+        .collect();
+    Ok(Json(json!({ "height": height, "bundles": bundles })))
+}
+
 async fn poawx_get_role_work(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -19615,6 +19643,7 @@ async fn main() {
         .route("/poawx/registration", post(poawx_post_registration))
         .route("/poawx/role-bundle", post(poawx_post_role_bundle))
         .route("/poawx/role-work", get(poawx_get_role_work))
+        .route("/poawx/collected-bundles", get(poawx_get_collected_bundles))
         .route("/poawx/finality-votes", get(poawx_finality_votes_get))
         .route("/rpc/submit_tx", post(submit_tx))
         // Fix D: pending-tx introspection + per-address pending-spent

--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -1654,6 +1654,16 @@ struct BlockTemplateResponse {
     poawx_reg_activations: Vec<String>,
     #[serde(default)]
     poawx_reg_announces: Vec<String>,
+    /// C2: contributor role-worker bundles collected for THIS height, as
+    /// "role_id:solver_pkh:score". A builder uses these to pay the collected workers
+    /// their own attributed addresses instead of fusing every role onto its own
+    /// identity. Empty when nothing has been collected, in which case a builder
+    /// behaves exactly as before.
+    #[serde(default)]
+    poawx_role_bundles: Vec<String>,
+    /// Count of distinct payees available across the collected roles.
+    #[serde(default)]
+    poawx_role_bundle_distinct_payees: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -13961,6 +13971,16 @@ async fn get_block_template(
         poawx_reg_required_sybil_bits: reg_required_sybil_bits,
         poawx_reg_activations: reg_activations,
         poawx_reg_announces: reg_announces,
+        poawx_role_bundles: {
+            let c = irium_node_rs::poawx_role_bundle::collect_roles_for_height(height);
+            [&c.compute, &c.verify, &c.support]
+                .into_iter()
+                .flatten()
+                .map(|b| format!("{}:{}:{}", b.role_id, hex::encode(b.solver_pkh), b.score()))
+                .collect()
+        },
+        poawx_role_bundle_distinct_payees: irium_node_rs::poawx_role_bundle::collect_roles_for_height(height)
+            .distinct_payees(),
     }))
 }
 
@@ -14547,6 +14567,57 @@ fn proposer_registration_bridge_guard(addr: &SocketAddr) -> Result<(), StatusCod
 /// POST /poawx/registration : a local miner submits a ProposerRegistrationV1 (wire
 /// bytes). The node light-validates, pools it, and gossips it so a producer can announce
 /// it on-chain. Loopback-only; mainnet hard-off.
+/// C1: loopback-only guard for the role-bundle collection endpoint.
+///
+/// LOOPBACK-ONLY IN THIS UNIT. Co-located miners (standalone CLI, GPU, Irium Core with a
+/// bundled node) can submit. A POOL miner submitting to a REMOTE pool node cannot yet --
+/// remote exposure is a separate, separately-approved unit. Do not read the existence of
+/// this endpoint as "all mining paths are collected".
+fn role_bundle_bridge_guard(addr: &SocketAddr) -> Result<(), StatusCode> {
+    if !addr.ip().is_loopback() {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    Ok(())
+}
+
+/// POST /poawx/role-bundle : a contributor role-worker submits its completed bundle.
+///
+/// The bundle is FULLY VALIDATED HERE, on ingest, not when a builder later uses it: the
+/// payout binding is recomputed rather than trusted and the ECVRF proof is verified.
+/// Rate-limited per source using the same limiter as the other gossip-adjacent ingests.
+async fn poawx_post_role_bundle(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+    body: axum::body::Bytes,
+) -> Result<Json<Value>, StatusCode> {
+    role_bundle_bridge_guard(&addr)?;
+    if !irium_node_rs::poawx_admission::admission_rate_allowed(addr.ip()) {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
+    let json_s = std::str::from_utf8(body.as_ref()).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let net = irium_node_rs::activation::network_id_byte();
+    let next_height = match state.chain.try_lock() {
+        Ok(g) => g.tip_height().saturating_add(1),
+        Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+    let pool = irium_node_rs::poawx_role_bundle::global_role_bundle_pool();
+    match pool.ingest_json(json_s, net, next_height, None) {
+        Ok(o) => Ok(Json(json!({
+            "status": match o {
+                irium_node_rs::poawx_role_bundle::BundleOutcome::AcceptedNew => "accepted",
+                irium_node_rs::poawx_role_bundle::BundleOutcome::ReplacedLower => "replaced",
+                irium_node_rs::poawx_role_bundle::BundleOutcome::Duplicate => "duplicate",
+            },
+            "height": next_height,
+            "collected": pool.len(),
+        }))),
+        Err(e) => {
+            eprintln!("[poawx] role bundle rejected: {e}");
+            Err(StatusCode::BAD_REQUEST)
+        }
+    }
+}
+
 async fn poawx_post_registration(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     State(state): State<AppState>,
@@ -19476,6 +19547,7 @@ async fn main() {
         // hard-off, disabled unless the finality gossip gate is configured).
         .route("/poawx/finality-vote", post(poawx_finality_vote_post))
         .route("/poawx/registration", post(poawx_post_registration))
+        .route("/poawx/role-bundle", post(poawx_post_role_bundle))
         .route("/poawx/finality-votes", get(poawx_finality_votes_get))
         .route("/rpc/submit_tx", post(submit_tx))
         // Fix D: pending-tx introspection + per-address pending-spent

--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -14574,10 +14574,66 @@ fn proposer_registration_bridge_guard(addr: &SocketAddr) -> Result<(), StatusCod
 /// remote exposure is a separate, separately-approved unit. Do not read the existence of
 /// this endpoint as "all mining paths are collected".
 fn role_bundle_bridge_guard(addr: &SocketAddr) -> Result<(), StatusCode> {
-    if !addr.ip().is_loopback() {
+    // R2: non-loopback sources are refused unless an operator has explicitly opted in.
+    // Default remains loopback-only, so this ships inert. R1's tiered limiting is the
+    // precondition for ever enabling it.
+    if !addr.ip().is_loopback()
+        && !irium_node_rs::poawx_role_bundle::role_bundle_public_submission_enabled()
+    {
         return Err(StatusCode::FORBIDDEN);
     }
     Ok(())
+}
+
+/// R3: GET /poawx/role-work — everything an independent contributor needs to build a
+/// bundle, WITHOUT holding an authenticated mining-template session.
+///
+/// The dominance snapshot is included deliberately and is not optional: per C3's
+/// finding, a worker computing against a different dominance view produces a bundle
+/// whose puzzle solution cannot verify against the builder's challenge, and it fails
+/// silently at assembly time. Shipping the other parameters without it would invite
+/// exactly that failure.
+async fn poawx_get_role_work(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    State(state): State<AppState>,
+) -> Result<Json<Value>, StatusCode> {
+    role_bundle_bridge_guard(&addr)?;
+    if !irium_node_rs::poawx_admission::admission_rate_allowed(addr.ip()) {
+        return Err(StatusCode::TOO_MANY_REQUESTS);
+    }
+    let g = match state.chain.try_lock() {
+        Ok(g) => g,
+        Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
+    };
+    let tip = g.tip_height();
+    let height = tip.saturating_add(1);
+    let prev_hash = g
+        .chain
+        .last()
+        .map(|b| b.header.hash_for_height(tip))
+        .unwrap_or_else(|| {
+            let mut o = [0u8; 32];
+            if let Ok(b) = hex::decode(&state.genesis_hash) {
+                if b.len() == 32 {
+                    o.copy_from_slice(&b);
+                }
+            }
+            o
+        });
+    let parent = g.chain.last().cloned();
+    let epoch_seed =
+        irium_node_rs::poawx_committed_admission::expected_epoch_seed(height, prev_hash, parent.as_ref());
+    let dominance = hex::encode(g.dominance_bytes());
+    drop(g);
+    Ok(Json(json!({
+        "height": height,
+        "prev_hash": hex::encode(prev_hash),
+        "epoch_seed": hex::encode(epoch_seed),
+        "puzzle_anchor_bits": irium_node_rs::poawx_puzzle::default_profile().anchor_bits,
+        "sybil_bits": irium_node_rs::poawx_ticket::effective_sybil_bits(),
+        "dominance_snapshot": dominance,
+        "note": "dominance_snapshot is REQUIRED: build against it or the puzzle solution will not verify at assembly",
+    })))
 }
 
 /// POST /poawx/role-bundle : a contributor role-worker submits its completed bundle.
@@ -14591,9 +14647,6 @@ async fn poawx_post_role_bundle(
     body: axum::body::Bytes,
 ) -> Result<Json<Value>, StatusCode> {
     role_bundle_bridge_guard(&addr)?;
-    if !irium_node_rs::poawx_admission::admission_rate_allowed(addr.ip()) {
-        return Err(StatusCode::TOO_MANY_REQUESTS);
-    }
     let json_s = std::str::from_utf8(body.as_ref()).map_err(|_| StatusCode::BAD_REQUEST)?;
     let net = irium_node_rs::activation::network_id_byte();
     let next_height = match state.chain.try_lock() {
@@ -14601,7 +14654,14 @@ async fn poawx_post_role_bundle(
         Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
     };
     let pool = irium_node_rs::poawx_role_bundle::global_role_bundle_pool();
-    match pool.ingest_json(json_s, net, next_height, None) {
+    let parsed = match irium_node_rs::poawx_role_bundle::RoleBundleV1::from_json(json_s) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("[poawx] role bundle parse rejected: {e}");
+            return Err(StatusCode::BAD_REQUEST);
+        }
+    };
+    match pool.ingest_tiered(addr.ip(), parsed, net, next_height, None) {
         Ok(o) => Ok(Json(json!({
             "status": match o {
                 irium_node_rs::poawx_role_bundle::BundleOutcome::AcceptedNew => "accepted",
@@ -19548,6 +19608,7 @@ async fn main() {
         .route("/poawx/finality-vote", post(poawx_finality_vote_post))
         .route("/poawx/registration", post(poawx_post_registration))
         .route("/poawx/role-bundle", post(poawx_post_role_bundle))
+        .route("/poawx/role-work", get(poawx_get_role_work))
         .route("/poawx/finality-votes", get(poawx_finality_votes_get))
         .route("/rpc/submit_tx", post(submit_tx))
         // Fix D: pending-tx introspection + per-address pending-spent

--- a/src/bin/iriumd.rs
+++ b/src/bin/iriumd.rs
@@ -14649,8 +14649,14 @@ async fn poawx_post_role_bundle(
     role_bundle_bridge_guard(&addr)?;
     let json_s = std::str::from_utf8(body.as_ref()).map_err(|_| StatusCode::BAD_REQUEST)?;
     let net = irium_node_rs::activation::network_id_byte();
-    let next_height = match state.chain.try_lock() {
-        Ok(g) => g.tip_height().saturating_add(1),
+    // R4: the SUPPORT finality vote binds to the PARENT block, so ingest needs it to
+    // check the vote names the parent we actually expect.
+    let (next_height, parent_hash) = match state.chain.try_lock() {
+        Ok(g) => {
+            let tip = g.tip_height();
+            let ph = g.chain.last().map(|b| b.header.hash_for_height(tip));
+            (tip.saturating_add(1), ph)
+        }
         Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
     };
     let pool = irium_node_rs::poawx_role_bundle::global_role_bundle_pool();
@@ -14661,7 +14667,7 @@ async fn poawx_post_role_bundle(
             return Err(StatusCode::BAD_REQUEST);
         }
     };
-    match pool.ingest_tiered(addr.ip(), parsed, net, next_height, None) {
+    match pool.ingest_tiered(addr.ip(), parsed, net, next_height, None, parent_hash) {
         Ok(o) => Ok(Json(json!({
             "status": match o {
                 irium_node_rs::poawx_role_bundle::BundleOutcome::AcceptedNew => "accepted",

--- a/src/bin/poawx-collected-proposer.rs
+++ b/src/bin/poawx-collected-proposer.rs
@@ -1,0 +1,164 @@
+//! DEV/TEST-ONLY multi-party proposer: assembles a block from the node's COLLECTED role
+//! bundles (fetched over HTTP from `/poawx/collected-bundles`) using ONLY its own
+//! proposer key. It never sees or holds any worker's private key — it consumes only the
+//! public bundles the workers submitted over the real `/poawx/role-bundle` endpoint. This
+//! turns the C3 "assembly from collected artifacts only" property into a real, separate
+//! process. Off mainnet / isolated devnet only.
+//!
+//! Env: IRIUM_POAWX_MINER_SECRET_HEX (the PROPOSER's payout/VRF key), IRIUM_NODE_RPC,
+//!      IRIUM_RPC_TOKEN, IRIUM_NETWORK=devnet.
+use irium_node_rs::poawx::{
+    ROLE_COMPUTE_CONTRIBUTOR, ROLE_SUPPORT_CONTRIBUTOR, ROLE_VERIFY_CONTRIBUTOR,
+};
+use irium_node_rs::poawx_miner_client::{
+    build_poawx_submit_request, fetch_block_template, poawx_decode_hash32, poawx_fetch_dominance,
+    poawx_fetch_parent_info, poawx_miner_secret, poawx_receipt_difficulty_bits,
+    poawx_submit_extended, rpc_client,
+};
+use irium_node_rs::poawx_mining_harness::{build_collected_poawx_block_with_parent, CollectedArtifacts};
+use irium_node_rs::poawx_role_bundle::RoleBundleV1;
+use std::{thread, time::Duration};
+
+fn fetch_collected(
+    http: &reqwest::blocking::Client,
+    base: &str,
+    token: &str,
+) -> Result<CollectedArtifacts, String> {
+    let v: serde_json::Value = http
+        .get(format!("{base}/poawx/collected-bundles"))
+        .bearer_auth(token)
+        .send()
+        .map_err(|e| format!("collected get: {e}"))?
+        .json()
+        .map_err(|e| format!("collected json: {e}"))?;
+    let mut c = CollectedArtifacts {
+        compute: None,
+        verify: None,
+        support: None,
+    };
+    if let Some(arr) = v.get("bundles").and_then(|x| x.as_array()) {
+        for b in arr {
+            // NOTE: from_json parses PUBLIC bundle data only — no private keys involved.
+            let rb = RoleBundleV1::from_json(&b.to_string())?;
+            match rb.role_id {
+                ROLE_COMPUTE_CONTRIBUTOR => c.compute = Some(rb),
+                ROLE_VERIFY_CONTRIBUTOR => c.verify = Some(rb),
+                ROLE_SUPPORT_CONTRIBUTOR => c.support = Some(rb),
+                _ => {}
+            }
+        }
+    }
+    Ok(c)
+}
+
+fn main() -> Result<(), String> {
+    let net = irium_node_rs::activation::network_id_byte();
+    if net == 0 {
+        return Err("refusing to run on mainnet (network_id == 0)".into());
+    }
+    // The ONLY private key this process ever holds is the proposer's own.
+    let secret = poawx_miner_secret()?;
+    let client = rpc_client()?;
+    let base = std::env::var("IRIUM_NODE_RPC").unwrap_or_else(|_| "http://127.0.0.1:38500".into());
+    let token = std::env::var("IRIUM_RPC_TOKEN").unwrap_or_default();
+    let http = reqwest::blocking::Client::new();
+    let diff = poawx_receipt_difficulty_bits();
+    println!("[proposer] collected-block proposer started (net={net}); assembles ONLY from collected bundles + its own key");
+
+    loop {
+        let tmpl = match fetch_block_template(&client, false) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("[proposer] template: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let height = tmpl.height;
+        let prev_hash = match poawx_decode_hash32(&tmpl.prev_hash) {
+            Ok(h) => h,
+            Err(e) => {
+                eprintln!("[proposer] prev_hash: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let bits = match u32::from_str_radix(tmpl.bits.trim_start_matches("0x"), 16) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("[proposer] bits: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let time = tmpl.time;
+
+        let collected = match fetch_collected(&http, &base, &token) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[proposer] {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let have = collected.compute.is_some() as u8
+            + collected.verify.is_some() as u8
+            + collected.support.is_some() as u8;
+        if have < 3 {
+            println!("[proposer] height={height}: waiting for workers ({have}/3 collected)");
+            thread::sleep(Duration::from_secs(2));
+            continue;
+        }
+
+        let (parent_prev_hash, parent_seed_components) = match poawx_fetch_parent_info(&client, height)
+        {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[proposer] parent info: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let dominance = match poawx_fetch_dominance(&client) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("[proposer] dominance: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+
+        let proof = match build_collected_poawx_block_with_parent(
+            &secret,
+            collected,
+            net,
+            height,
+            prev_hash,
+            parent_prev_hash,
+            bits,
+            time,
+            diff,
+            parent_seed_components,
+            Some(&dominance),
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[proposer] build_collected failed at {height}: {e}");
+                thread::sleep(Duration::from_secs(2));
+                continue;
+            }
+        };
+        let req = match build_poawx_submit_request(&proof) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[proposer] submit build: {e}");
+                continue;
+            }
+        };
+        match poawx_submit_extended(&client, &req) {
+            Ok(()) => println!("[proposer] SUBMITTED collected block height={height} (proposer + 3 independent workers)"),
+            Err(e) => eprintln!("[proposer] submit failed at {height}: {e}"),
+        }
+        thread::sleep(Duration::from_secs(2));
+    }
+}

--- a/src/bin/poawx-role-worker.rs
+++ b/src/bin/poawx-role-worker.rs
@@ -15,6 +15,7 @@ use irium_node_rs::poawx::{
     ROLE_SUPPORT_CONTRIBUTOR, ROLE_VERIFY_CONTRIBUTOR,
 };
 use irium_node_rs::poawx_candidate::{AssignmentProofV2, RoleCandidate};
+use irium_node_rs::poawx_dominance::{PersistentDominance, DOMINANCE_BASE_WORK_SCORE};
 use irium_node_rs::poawx_penalty::PenaltyStatus;
 use irium_node_rs::poawx_puzzle::{profile_with_bits, solve_dev, verify_solution, PuzzleChallengeV1};
 use irium_node_rs::poawx_ticket::{grind_sybil_nonce, TicketProof};
@@ -59,30 +60,51 @@ fn main() -> Result<(), String> {
     payout_pubkey.copy_from_slice(VerifyingKey::from(&sk).to_encoded_point(true).as_bytes());
     let payout_pkh = hash160(&payout_pubkey);
 
-    // ---- fetch the node template (isolated rig) ----
+    // ---- fetch the R3 role-work params (works regardless of proposer-VRF: the epoch
+    //      seed used for role assignments is provided here, not the proposer-VRF seed) ----
     let base = std::env::var("IRIUM_NODE_RPC").unwrap_or_else(|_| "http://127.0.0.1:38500".into());
     let token = std::env::var("IRIUM_RPC_TOKEN").unwrap_or_default();
     let client = reqwest::blocking::Client::new();
     let t: serde_json::Value = client
-        .get(format!("{base}/rpc/getblocktemplate"))
+        .get(format!("{base}/poawx/role-work"))
         .bearer_auth(&token)
         .send()
-        .map_err(|e| format!("template fetch: {e}"))?
+        .map_err(|e| format!("role-work fetch: {e}"))?
         .json()
-        .map_err(|e| format!("template json: {e}"))?;
-    let height = t["height"].as_u64().ok_or("template: no height")?;
-    let prev_hash = h32(t["prev_hash"].as_str().ok_or("template: no prev_hash")?);
+        .map_err(|e| format!("role-work json: {e}"))?;
+    let height = t["height"].as_u64().ok_or("role-work: no height")?;
+    let prev_hash = h32(t["prev_hash"].as_str().ok_or("role-work: no prev_hash")?);
     let seed = h32(
-        t["poawx_proposer_seed"]
+        t["epoch_seed"]
             .as_str()
-            .ok_or("template: no poawx_proposer_seed (epoch seed) -- proposer-VRF must be active")?,
+            .ok_or("role-work: no epoch_seed")?,
     );
-    let puzzle_bits = t["poawx_puzzle_anchor_bits"].as_u64().unwrap_or(8) as u8;
-    let sybil_bits = t["poawx_effective_sybil_bits"].as_u64().unwrap_or(8) as u32;
+    let puzzle_bits = t["puzzle_anchor_bits"].as_u64().unwrap_or(8) as u8;
+    let sybil_bits = t["sybil_bits"].as_u64().unwrap_or(8) as u32;
     let profile = profile_with_bits(puzzle_bits);
     let epoch = height;
 
-    println!("[role-worker] role={role_name} height={height} net={net} payout_pkh={} sybil_bits={sybil_bits} puzzle_bits={puzzle_bits}", hex::encode(payout_pkh));
+    // Node-authoritative dominance: the candidate's `dominance_weight` is consensus-validated
+    // (chain.rs `validate_block_dominance_weights`) against the node's persisted dominance, and
+    // it is serialized into the candidate whose SHA-256 digest seeds the puzzle challenge. So it
+    // MUST be derived from the node's snapshot, never hardcoded. Hardcoding 1000 happens to equal
+    // the node weight only when dominance is empty (height 1: fairness_weight = 1000*1000/1000);
+    // at height >= 2 the parent block credits reward share to the solver pkhs, the node weight
+    // falls below 1000, and the worker's puzzle challenge stops matching the builder's rebuilt
+    // one -> "proof digest mismatch" at assembly. The endpoint ships this snapshot precisely so
+    // the worker can build against it (see role-work's dominance note).
+    let dominance = PersistentDominance::from_bytes(
+        &hex::decode(
+            t["dominance_snapshot"]
+                .as_str()
+                .ok_or("role-work: no dominance_snapshot")?
+                .trim(),
+        )
+        .map_err(|e| format!("dominance_snapshot hex: {e}"))?,
+    )?;
+    let dominance_weight = dominance.weight(DOMINANCE_BASE_WORK_SCORE, &payout_pkh, height);
+
+    println!("[role-worker] role={role_name} height={height} net={net} payout_pkh={} sybil_bits={sybil_bits} puzzle_bits={puzzle_bits} dominance_weight={dominance_weight}", hex::encode(payout_pkh));
 
     // ---- 1. real sybil ticket (bound to prev_hash + payout identity) ----
     let nonce = if sybil_bits > 0 {
@@ -101,7 +123,8 @@ fn main() -> Result<(), String> {
     //     assignment ticket_digest mirrors the accepted harness pattern (per-role constant).
     let a_ticket = [(0x11u8 + role); 32];
     let proof = AssignmentProofV2::prove_self_solver(&secret, net, height, role, a_ticket, seed)?;
-    let cand = RoleCandidate::from_assignment_v2(&proof, PenaltyStatus::Clean.id(), 1000, [role; 32]);
+    let cand =
+        RoleCandidate::from_assignment_v2(&proof, PenaltyStatus::Clean.id(), dominance_weight, [role; 32]);
 
     // ---- 3. real assigned puzzle solution (the genuine role WORK) ----
     let cdg: [u8; 32] = Sha256::digest(cand.serialize()).into();
@@ -157,9 +180,30 @@ fn main() -> Result<(), String> {
         return Err("precommit commitment mismatch".into());
     }
 
-    // ---- 6. emit the payout-bound bundle (for the Phase-3 collection channel) ----
+    // ---- 6. R4: SUPPORT doubles as the finality committee member, so it self-signs its
+    //         OWN finality vote (the builder holds no key for it). The vote finalizes the
+    //         PARENT (block_hash = prev_hash), bound to this worker's real ticket_digest.
+    let finality_vote = if role == ROLE_SUPPORT_CONTRIBUTOR {
+        let v = irium_node_rs::poawx_finality::FinalityVoteV1::signed(
+            &sk,
+            net,
+            height,
+            prev_hash,
+            [0u8; 32],
+            0,
+            ticket.ticket_digest,
+            irium_node_rs::poawx_finality::FinalityVoteType::Commit,
+        );
+        // self-verify the vote binds correctly before emitting
+        v.verify(net, height, &prev_hash)?;
+        Some(v)
+    } else {
+        None
+    };
+
+    // ---- 7. emit the payout-bound bundle (for the Phase-3 collection channel) ----
     println!("[role-worker] ALL ARTIFACTS SELF-VERIFIED. Phase-1 binding holds: solver_pkh == hash160(assignment_public_key) == payout_pkh.");
-    let bundle = serde_json::json!({
+    let mut bundle = serde_json::json!({
         "network_id": net, "target_height": height, "role_id": role, "role": role_name,
         "solver_pkh": hex::encode(payout_pkh),
         "assignment_public_key": hex::encode(payout_pubkey),
@@ -172,6 +216,9 @@ fn main() -> Result<(), String> {
             "commitment_hash": hex::encode(commitment), "claim_digest": hex::encode(claim_digest),
         },
     });
+    if let Some(v) = &finality_vote {
+        bundle["finality_vote"] = serde_json::Value::String(hex::encode(v.serialize()));
+    }
     println!("{}", serde_json::to_string_pretty(&bundle).unwrap());
     Ok(())
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -11914,7 +11914,7 @@ mod tests {
         let _ = ks;
         // Each collected bundle is self-validating public material -- no secrets.
         for b in [&collected.compute, &collected.verify].into_iter().flatten() {
-            b.validate(net, 2, Some(seed2)).expect("collected bundle validates");
+            b.validate(net, 2, Some(seed2), Some(h1_hash)).expect("collected bundle validates");
         }
 
         let pc2 = seed_components_from_block(st.chain.last());
@@ -11960,7 +11960,8 @@ mod tests {
         std::env::remove_var("IRIUM_NETWORK");
     }
 
-    /// R1-R3 PROOF: two INDEPENDENT remote workers submit across a simulated source
+    /// R1-R4 COMPLETION PROOF: THREE independent remote workers (COMPUTE, VERIFY and
+    /// SUPPORT) submit across a simulated source
     /// boundary, both are collected through the tiered ingest path, and the assembled
     /// block is accepted by connect_block paying both.
     ///
@@ -11969,7 +11970,7 @@ mod tests {
     /// source addresses, passing per-source limiting, full validation, and per-identity
     /// limiting before ever being poolable.
     #[test]
-    fn r1_r3_two_remote_workers_collected_and_assembled() {
+    fn r1_r4_three_remote_workers_collected_and_assembled() {
         use crate::poawx_admission::global_admission_cache;
         use crate::poawx_committed_admission::{expected_epoch_seed, seed_components_from_block};
         use crate::poawx_mining_harness::{
@@ -12025,16 +12026,25 @@ mod tests {
         };
         let b_compute = mk(&kc, crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, [0x11u8; 32]);
         let b_verify = mk(&kv, crate::poawx::ROLE_VERIFY_CONTRIBUTOR, [0x12u8; 32]);
+        // R4: SUPPORT now carries its OWN finality vote, so it is collectable too.
+        let b_support = mk(&ks, crate::poawx::ROLE_SUPPORT_CONTRIBUTOR, [0x13u8; 32]);
+        assert!(
+            b_support.finality_vote.is_some(),
+            "a SUPPORT bundle must carry its own committee vote"
+        );
 
         // THE BOUNDARY: they arrive over the tiered ingest path from DISTINCT sources.
         let pool = global_role_bundle_pool();
         pool.prune_below(2);
         let src_a = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
         let src_b = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9));
-        pool.ingest_tiered(src_a, b_compute, net, 2, Some(seed2))
+        pool.ingest_tiered(src_a, b_compute, net, 2, Some(seed2), Some(h1_hash))
             .expect("remote worker A accepted");
-        pool.ingest_tiered(src_b, b_verify, net, 2, Some(seed2))
+        pool.ingest_tiered(src_b, b_verify, net, 2, Some(seed2), Some(h1_hash))
             .expect("remote worker B accepted");
+        let src_c = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 5));
+        pool.ingest_tiered(src_c, b_support, net, 2, Some(seed2), Some(h1_hash))
+            .expect("remote worker C (SUPPORT) accepted");
 
         // Collected purely from what arrived over the wire -- no local secrets consulted.
         let got_c: RoleBundleV1 = pool
@@ -12045,10 +12055,14 @@ mod tests {
             .expect("verify collected from the pool");
         assert_eq!(got_c.solver_pkh, cpkh);
         assert_eq!(got_v.solver_pkh, vpkh);
+        let got_s: RoleBundleV1 = pool
+            .best_for_role(crate::poawx::ROLE_SUPPORT_CONTRIBUTOR, 2)
+            .expect("support collected from the pool");
+        let spkh = got_s.solver_pkh;
         let collected = CollectedArtifacts {
             compute: Some(got_c),
             verify: Some(got_v),
-            support: None,
+            support: Some(got_s),
         };
 
         let pc2 = seed_components_from_block(st.chain.last());
@@ -12069,7 +12083,13 @@ mod tests {
         assert_eq!(st.tip_height(), 2);
         assert_eq!(cb.outputs[2].script_pubkey, crate::tx::p2pkh_script(&cpkh), "COMPUTE -> remote worker A");
         assert_eq!(cb.outputs[3].script_pubkey, crate::tx::p2pkh_script(&vpkh), "VERIFY -> remote worker B");
-        assert_ne!(cpkh, vpkh, "two genuinely independent remote workers");
+        assert_eq!(cb.outputs[4].script_pubkey, crate::tx::p2pkh_script(&spkh), "SUPPORT -> remote worker C");
+        let distinct: std::collections::BTreeSet<_> = [cpkh, vpkh, spkh].into_iter().collect();
+        assert_eq!(distinct.len(), 3, "three genuinely independent remote workers");
+        assert!(
+            !distinct.contains(&pkh_of(&skf(&worker))),
+            "no collected role may be paid to the builder"
+        );
         pool.prune_below(3);
         for (k, _) in gates {
             std::env::remove_var(k);

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -11786,6 +11786,243 @@ mod tests {
         std::env::remove_var("IRIUM_NETWORK");
     }
 
+    /// The mainnet-faithful gate set the C3 proofs run under: every PoAW-X gate active
+    /// AND the contributor-role-binding rule active, matching the existing rig tests.
+    fn c3_gate_set() -> [(&'static str, &'static str); 32] {
+        [
+            ("IRIUM_POAWX_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_MODE", "active"),
+            ("IRIUM_POAWX_PUZZLE_DIFFICULTY_BITS", "1"),
+            ("IRIUM_POAWX_PUZZLE_BITS", "1"),
+            ("IRIUM_POAWX_MULTI_ROLE_REWARD_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_FAIRNESS_MATRIX_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ANTI_DOMINATION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ANTI_DOMINATION_REQUIRED", "1"),
+            ("IRIUM_POAWX_CANDIDATE_SET_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_CANDIDATE_SET_REQUIRED", "1"),
+            ("IRIUM_POAWX_ASSIGNMENT_PROOF_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_ASSIGNMENT_PROOF_REQUIRED", "1"),
+            ("IRIUM_POAWX_CANDIDATE_ADMISSION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_CANDIDATE_ADMISSION_REQUIRED", "1"),
+            ("IRIUM_POAWX_CANDIDATE_ADMISSION_WINDOW", "64"),
+            ("IRIUM_POAWX_PUZZLE_WORK_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PUZZLE_WORK_REQUIRED", "1"),
+            ("IRIUM_POAWX_FINALITY_COMMITTEE_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_FINALITY_COMMITTEE_REQUIRED", "1"),
+            ("IRIUM_POAWX_FINALITY_THRESHOLD_NUM", "1"),
+            ("IRIUM_POAWX_FINALITY_THRESHOLD_DEN", "1"),
+            ("IRIUM_POAWX_COMMITTED_ADMISSION_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_COMMITTED_ADMISSION_REQUIRED", "1"),
+            ("IRIUM_POAWX_COMMITTED_ADMISSION_WINDOW", "64"),
+            ("IRIUM_POAWX_TRUE_VRF_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_TRUE_VRF_REQUIRED", "1"),
+            ("IRIUM_POAWX_MULTISOURCE_SEED_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_HIDDEN_PRECOMMIT_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PENALTY_STATE_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PENALTY_STATE_REQUIRED", "1"),
+            ("IRIUM_POAWX_CONTRIBUTOR_ROLE_BINDING_ACTIVATION_HEIGHT", "1"),
+            ("IRIUM_POAWX_PROPOSER_VRF_ACTIVATION_HEIGHT", "999999"),
+        ]
+    }
+
+    /// C3 PROOF: a block assembled ONLY from collected public artifacts is accepted by
+    /// connect_block and pays the collected workers their own addresses.
+    ///
+    /// The builder is handed `CollectedArtifacts` and its OWN worker secret. It never
+    /// receives any contributor's private key -- that is the property every pre-C3
+    /// builder could not express, and the property real collection requires.
+    ///
+    /// The fixture is deliberately NOT simplified around the dominance dependency. It
+    /// runs to height 2 so that block 1's rewards make the dominance weights non-uniform,
+    /// and the workers compute their artifacts against the SAME snapshot the builder
+    /// uses -- exactly as a real worker would, reading it from its node. The puzzle
+    /// challenge is bound to sha256(candidate.serialize()) and the candidate carries its
+    /// dominance weight, so a disagreement here would break assembly. The companion
+    /// negative control proves that.
+    #[test]
+    fn c3_block_assembled_from_collected_artifacts_only() {
+        use crate::poawx_admission::global_admission_cache;
+        use crate::poawx_committed_admission::{expected_epoch_seed, seed_components_from_block};
+        use crate::poawx_mining_harness::{
+            build_collected_poawx_block_with_parent, build_multi_participant_poawx_block_with_parent,
+            simulate_role_worker_bundle, CollectedArtifacts,
+        };
+        let _g = chain_poawx_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        let gates = c3_gate_set();
+        for (k, v) in gates {
+            std::env::set_var(k, v);
+        }
+        let skf = |b: &[u8; 32]| k256::ecdsa::SigningKey::from_bytes(b.into()).unwrap();
+        let pkh_of = |sk: &k256::ecdsa::SigningKey| -> [u8; 20] {
+            hash160(sk.verifying_key().to_encoded_point(true).as_bytes())
+        };
+        let (worker, kc, kv, ks) = ([0x4Du8; 32], [0x61u8; 32], [0x62u8; 32], [0x63u8; 32]);
+        let worker_pkh = pkh_of(&skf(&worker));
+        let (cpkh, vpkh, spkh) = (pkh_of(&skf(&kc)), pkh_of(&skf(&kv)), pkh_of(&skf(&ks)));
+
+        let locked = load_locked_genesis().expect("locked genesis");
+        let genesis = block_from_locked(&locked).expect("genesis block");
+        let genesis_hash = genesis.header.hash_for_height(0);
+        let mut st = base_chain(None);
+        let net = crate::activation::network_id_byte();
+        let cache = global_admission_cache();
+
+        // ---- H1: an ordinary multi-participant block, so H2's dominance is NON-UNIFORM.
+        let pc1 = seed_components_from_block(st.chain.last());
+        let bits1 = st.target_for_height(1).bits;
+        let p1 = build_multi_participant_poawx_block_with_parent(
+            &worker, &kc, &kv, &ks, net, 1, genesis_hash, None, bits1,
+            genesis.header.time + 1, 1, pc1,
+        )
+        .expect("build H1");
+        cache.clear();
+        cache.set_tip(1);
+        for a in &p1.admissions {
+            let _ = cache.ingest_bytes(a);
+        }
+        let h1_hash = p1.block_hash;
+        st.connect_block(p1.block).expect("connect H1");
+        assert_eq!(st.tip_height(), 1);
+
+        // ---- H2: workers produce artifacts against the node's REAL dominance snapshot.
+        let dom = st.dominance.clone();
+        let parent = st.chain.last().cloned().expect("parent");
+        let seed2 = expected_epoch_seed(2, h1_hash, Some(&parent));
+        let profile = crate::poawx_puzzle::default_profile();
+        let mk_bundle = |sec: &[u8; 32], role: u8, td: [u8; 32]| {
+            simulate_role_worker_bundle(sec, net, 2, role, td, seed2, h1_hash, &dom, profile)
+                .unwrap_or_else(|e| panic!("worker bundle role {role}: {e}"))
+        };
+        // COMPUTE and VERIFY are collected from foreign workers. SUPPORT is deliberately
+        // NOT collected here, and that is a finding rather than a convenience:
+        //
+        //   SUPPORT doubles as the FINALITY COMMITTEE MEMBER. The block's finality vote
+        //   is signed by `AllGatesIdentities.member_sk` and the committee is derived from
+        //   the block's SUPPORT candidate, so a collected SUPPORT worker would have to
+        //   supply its own finality VOTE as well -- which the builder cannot produce on
+        //   its behalf and which poawx-role-worker does not currently emit. Collecting
+        //   SUPPORT therefore needs a bundle-format extension, tracked separately.
+        //
+        // Two collected roles still establish the property under test: a block assembled
+        // from public artifacts alone, paying multiple distinct workers.
+        let collected = CollectedArtifacts {
+            compute: Some(mk_bundle(&kc, crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, [0x11u8; 32])),
+            verify: Some(mk_bundle(&kv, crate::poawx::ROLE_VERIFY_CONTRIBUTOR, [0x12u8; 32])),
+            support: None,
+        };
+        let _ = ks;
+        // Each collected bundle is self-validating public material -- no secrets.
+        for b in [&collected.compute, &collected.verify].into_iter().flatten() {
+            b.validate(net, 2, Some(seed2)).expect("collected bundle validates");
+        }
+
+        let pc2 = seed_components_from_block(st.chain.last());
+        let bits2 = st.target_for_height(2).bits;
+        // THE POINT: only `worker` is secret here. The three contributors are public data.
+        let p2 = build_collected_poawx_block_with_parent(
+            &worker, collected, net, 2, h1_hash, Some(genesis_hash), bits2,
+            genesis.header.time + 2, 1, pc2, Some(&dom),
+        )
+        .expect("assemble H2 from collected artifacts only");
+        let cb = p2.block.transactions[0].clone();
+        cache.clear();
+        cache.set_tip(2);
+        for a in &p2.admissions {
+            let _ = cache.ingest_bytes(a);
+        }
+        st.connect_block(p2.block)
+            .expect("connect_block must ACCEPT a block assembled from collected artifacts");
+        assert_eq!(st.tip_height(), 2, "collected-artifact block landed");
+
+        // ---- the coinbase pays the collected workers, not the builder ----
+        assert_eq!(cb.outputs[1].script_pubkey, crate::tx::p2pkh_script(&worker_pkh), "PRIMARY -> builder");
+        assert_eq!(cb.outputs[2].script_pubkey, crate::tx::p2pkh_script(&cpkh), "COMPUTE -> collected worker");
+        assert_eq!(cb.outputs[3].script_pubkey, crate::tx::p2pkh_script(&vpkh), "VERIFY -> collected worker");
+        let _ = spkh;
+        // The two COLLECTED roles are paid to workers whose secrets the builder never had.
+        let collected_payees: std::collections::BTreeSet<_> =
+            (2..=3usize).map(|i| cb.outputs[i].script_pubkey.clone()).collect();
+        assert_eq!(collected_payees.len(), 2, "two DISTINCT collected payees");
+        assert!(
+            !collected_payees.contains(&crate::tx::p2pkh_script(&worker_pkh)),
+            "a collected role must NOT be paid to the builder"
+        );
+        let payees: std::collections::BTreeSet<_> =
+            (1..=4usize).map(|i| cb.outputs[i].script_pubkey.clone()).collect();
+        assert!(payees.len() >= 3, "block pays multiple distinct participants");
+        for i in 1..=4usize {
+            assert!(cb.outputs[i].value > 0, "coinbase output {i} funded");
+        }
+        for (k, _) in gates {
+            std::env::remove_var(k);
+        }
+        std::env::remove_var("IRIUM_NETWORK");
+    }
+
+    /// NEGATIVE CONTROL for the dominance-agreement dependency found while scoping C3.
+    /// A worker that computes its artifacts against a DIFFERENT dominance view produces
+    /// a puzzle solution bound to a different candidate digest, and assembly must fail
+    /// LOUDLY rather than emit a block that would be rejected on-chain.
+    #[test]
+    fn c3_dominance_disagreement_breaks_assembly_explicitly() {
+        use crate::poawx_committed_admission::{expected_epoch_seed, seed_components_from_block};
+        use crate::poawx_mining_harness::{
+            build_collected_poawx_block_with_parent, simulate_role_worker_bundle, CollectedArtifacts,
+        };
+        let _g = chain_poawx_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        let gates = c3_gate_set();
+        for (k, v) in gates {
+            std::env::set_var(k, v);
+        }
+        let (worker, kc) = ([0x4Du8; 32], [0x71u8; 32]);
+        let locked = load_locked_genesis().expect("locked genesis");
+        let genesis = block_from_locked(&locked).expect("genesis block");
+        let genesis_hash = genesis.header.hash_for_height(0);
+        let st = base_chain(None);
+        let net = crate::activation::network_id_byte();
+        let seed1 = expected_epoch_seed(1, genesis_hash, None);
+        let profile = crate::poawx_puzzle::default_profile();
+
+        // A dominance view the builder does NOT share: the worker believes this pkh has
+        // already earned, so it computes a different weight, hence a different candidate
+        // digest, hence a puzzle solution bound to a challenge the builder never derives.
+        let mut skewed = crate::poawx_dominance::PersistentDominance::new(
+            crate::poawx_dominance::DEFAULT_ANTI_DOMINATION_WINDOW,
+            crate::poawx_dominance::DEFAULT_ANTI_DOMINATION_LOOKBACK,
+        );
+        let sk = k256::ecdsa::SigningKey::from_bytes(&kc.into()).unwrap();
+        let cpkh = hash160(sk.verifying_key().to_encoded_point(true).as_bytes());
+        skewed.apply_event(cpkh, crate::poawx_dominance::RoleRewardKind::Primary, 5_000_000_000, 1);
+
+        let bundle = simulate_role_worker_bundle(
+            &kc, net, 1, crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, [0x11u8; 32], seed1,
+            genesis_hash, &skewed, profile,
+        )
+        .expect("worker builds against its own (skewed) view");
+        let collected = CollectedArtifacts { compute: Some(bundle), ..Default::default() };
+        let pc = seed_components_from_block(st.chain.last());
+        let bits = st.target_for_height(1).bits;
+        // Builder uses the EMPTY (true) dominance view -> weights disagree.
+        let res = build_collected_poawx_block_with_parent(
+            &worker, collected, net, 1, genesis_hash, None, bits,
+            genesis.header.time + 1, 1, pc, None,
+        );
+        let err = match res {
+            Err(e) => e,
+            Ok(_) => panic!("assembly MUST fail when the worker's dominance view disagrees"),
+        };
+        assert!(
+            err.contains("does not verify against its challenge"),
+            "must fail with the specific challenge-mismatch error, got: {err}"
+        );
+        for (k, _) in gates {
+            std::env::remove_var(k);
+        }
+        std::env::remove_var("IRIUM_NETWORK");
+    }
+
     #[test]
     #[ignore] // rig: reads REAL role-worker bundles from IRIUM_M3_DIR and lands their attributed identities on-chain
     fn phase4_real_worker_bundles_land_block_distinct_recipients() {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -11960,6 +11960,123 @@ mod tests {
         std::env::remove_var("IRIUM_NETWORK");
     }
 
+    /// R1-R3 PROOF: two INDEPENDENT remote workers submit across a simulated source
+    /// boundary, both are collected through the tiered ingest path, and the assembled
+    /// block is accepted by connect_block paying both.
+    ///
+    /// This is C3's proof extended across the network boundary R2 opens: the bundles do
+    /// not appear in the pool by fiat, they arrive via `ingest_tiered` from two distinct
+    /// source addresses, passing per-source limiting, full validation, and per-identity
+    /// limiting before ever being poolable.
+    #[test]
+    fn r1_r3_two_remote_workers_collected_and_assembled() {
+        use crate::poawx_admission::global_admission_cache;
+        use crate::poawx_committed_admission::{expected_epoch_seed, seed_components_from_block};
+        use crate::poawx_mining_harness::{
+            build_collected_poawx_block_with_parent, build_multi_participant_poawx_block_with_parent,
+            simulate_role_worker_bundle, CollectedArtifacts,
+        };
+        use crate::poawx_role_bundle::{global_role_bundle_pool, RoleBundleV1};
+        use std::net::{IpAddr, Ipv4Addr};
+        let _g = chain_poawx_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("IRIUM_NETWORK", "devnet");
+        let gates = c3_gate_set();
+        for (k, v) in gates {
+            std::env::set_var(k, v);
+        }
+        let skf = |b: &[u8; 32]| k256::ecdsa::SigningKey::from_bytes(b.into()).unwrap();
+        let pkh_of = |sk: &k256::ecdsa::SigningKey| -> [u8; 20] {
+            hash160(sk.verifying_key().to_encoded_point(true).as_bytes())
+        };
+        let (worker, kc, kv, ks) = ([0x4Du8; 32], [0x81u8; 32], [0x82u8; 32], [0x83u8; 32]);
+        let (cpkh, vpkh) = (pkh_of(&skf(&kc)), pkh_of(&skf(&kv)));
+
+        let locked = load_locked_genesis().expect("locked genesis");
+        let genesis = block_from_locked(&locked).expect("genesis block");
+        let genesis_hash = genesis.header.hash_for_height(0);
+        let mut st = base_chain(None);
+        let net = crate::activation::network_id_byte();
+        let cache = global_admission_cache();
+
+        // H1 so H2's dominance is non-uniform, as in the C3 proof.
+        let pc1 = seed_components_from_block(st.chain.last());
+        let bits1 = st.target_for_height(1).bits;
+        let p1 = build_multi_participant_poawx_block_with_parent(
+            &worker, &kc, &kv, &ks, net, 1, genesis_hash, None, bits1,
+            genesis.header.time + 1, 1, pc1,
+        )
+        .expect("build H1");
+        cache.clear();
+        cache.set_tip(1);
+        for a in &p1.admissions {
+            let _ = cache.ingest_bytes(a);
+        }
+        let h1_hash = p1.block_hash;
+        st.connect_block(p1.block).expect("connect H1");
+
+        // Two workers build against the node's dominance snapshot, as R3 serves it.
+        let dom = st.dominance.clone();
+        let parent = st.chain.last().cloned().expect("parent");
+        let seed2 = expected_epoch_seed(2, h1_hash, Some(&parent));
+        let profile = crate::poawx_puzzle::default_profile();
+        let mk = |sec: &[u8; 32], role: u8, td: [u8; 32]| {
+            simulate_role_worker_bundle(sec, net, 2, role, td, seed2, h1_hash, &dom, profile)
+                .expect("worker bundle")
+        };
+        let b_compute = mk(&kc, crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, [0x11u8; 32]);
+        let b_verify = mk(&kv, crate::poawx::ROLE_VERIFY_CONTRIBUTOR, [0x12u8; 32]);
+
+        // THE BOUNDARY: they arrive over the tiered ingest path from DISTINCT sources.
+        let pool = global_role_bundle_pool();
+        pool.prune_below(2);
+        let src_a = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        let src_b = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9));
+        pool.ingest_tiered(src_a, b_compute, net, 2, Some(seed2))
+            .expect("remote worker A accepted");
+        pool.ingest_tiered(src_b, b_verify, net, 2, Some(seed2))
+            .expect("remote worker B accepted");
+
+        // Collected purely from what arrived over the wire -- no local secrets consulted.
+        let got_c: RoleBundleV1 = pool
+            .best_for_role(crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, 2)
+            .expect("compute collected from the pool");
+        let got_v: RoleBundleV1 = pool
+            .best_for_role(crate::poawx::ROLE_VERIFY_CONTRIBUTOR, 2)
+            .expect("verify collected from the pool");
+        assert_eq!(got_c.solver_pkh, cpkh);
+        assert_eq!(got_v.solver_pkh, vpkh);
+        let collected = CollectedArtifacts {
+            compute: Some(got_c),
+            verify: Some(got_v),
+            support: None,
+        };
+
+        let pc2 = seed_components_from_block(st.chain.last());
+        let bits2 = st.target_for_height(2).bits;
+        let p2 = build_collected_poawx_block_with_parent(
+            &worker, collected, net, 2, h1_hash, Some(genesis_hash), bits2,
+            genesis.header.time + 2, 1, pc2, Some(&dom),
+        )
+        .expect("assemble H2 from REMOTELY collected artifacts");
+        let cb = p2.block.transactions[0].clone();
+        cache.clear();
+        cache.set_tip(2);
+        for a in &p2.admissions {
+            let _ = cache.ingest_bytes(a);
+        }
+        st.connect_block(p2.block)
+            .expect("connect_block must ACCEPT a block built from remotely collected work");
+        assert_eq!(st.tip_height(), 2);
+        assert_eq!(cb.outputs[2].script_pubkey, crate::tx::p2pkh_script(&cpkh), "COMPUTE -> remote worker A");
+        assert_eq!(cb.outputs[3].script_pubkey, crate::tx::p2pkh_script(&vpkh), "VERIFY -> remote worker B");
+        assert_ne!(cpkh, vpkh, "two genuinely independent remote workers");
+        pool.prune_below(3);
+        for (k, _) in gates {
+            std::env::remove_var(k);
+        }
+        std::env::remove_var("IRIUM_NETWORK");
+    }
+
     /// NEGATIVE CONTROL for the dominance-agreement dependency found while scoping C3.
     /// A worker that computes its artifacts against a DIFFERENT dominance view produces
     /// a puzzle solution bound to a different candidate digest, and assembly must fail

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod poawx_mining_harness;
 pub mod poawx_penalty;
 pub mod poawx_proposer;
 pub mod poawx_puzzle;
+pub mod poawx_role_bundle;
 pub mod poawx_ticket;
 pub mod pow;
 pub mod protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ mod poawx_mining_harness;
 mod poawx_penalty;
 mod poawx_proposer;
 mod poawx_puzzle;
+mod poawx_role_bundle;
 mod poawx_ticket;
 mod protocol;
 mod qr;

--- a/src/poawx_mining_harness.rs
+++ b/src/poawx_mining_harness.rs
@@ -549,6 +549,7 @@ pub fn build_collected_poawx_block_with_parent(
     time: u32,
     receipt_difficulty_bits: u32,
     parent_seed_components: ([u8; 32], [u8; 32]),
+    dominance_override: Option<&PersistentDominance>,
 ) -> Result<AllGatesProof, String> {
     build_all_gates_block_with(
         &AllGatesIdentities::with_collected(worker_secret, collected)?,
@@ -560,12 +561,96 @@ pub fn build_collected_poawx_block_with_parent(
         time,
         receipt_difficulty_bits,
         parent_seed_components,
-        None,
+        dominance_override,
         None,
         None,
         None,
         &default_cpu_nonce_solver,
     )
+}
+
+/// TEST/RIG SUPPORT: reproduce exactly what an independent role-worker computes, so a
+/// fixture can hand a builder ONLY public artifacts.
+///
+/// This deliberately mirrors `build_roles`' `mk` and the puzzle loop rather than
+/// inventing a parallel derivation -- the whole point is that the worker and the builder
+/// must agree. In particular the candidate carries its DOMINANCE WEIGHT and the
+/// effective score derived from it, and the puzzle challenge is bound to
+/// `sha256(candidate.serialize())`. A worker computing a different weight therefore
+/// produces a solution that cannot verify against the builder's challenge.
+#[allow(clippy::too_many_arguments)]
+pub fn simulate_role_worker_bundle(
+    worker_secret: &[u8; 32],
+    network_id: u8,
+    height: u64,
+    role: u8,
+    ticket_digest: [u8; 32],
+    epoch_seed: [u8; 32],
+    prev_hash: [u8; 32],
+    dominance: &PersistentDominance,
+    profile: crate::poawx_puzzle::PuzzleDifficultyProfile,
+) -> Result<crate::poawx_role_bundle::RoleBundleV1, String> {
+    let sk = SigningKey::from_bytes(worker_secret.into()).map_err(|_| "bad key".to_string())?;
+    let pt = sk.verifying_key().to_encoded_point(true);
+    let solver = hash160(pt.as_bytes());
+    let mut apk = [0u8; 33];
+    apk.copy_from_slice(pt.as_bytes());
+
+    let proof = AssignmentProofV2::prove(
+        worker_secret, network_id, height, role, solver, ticket_digest, epoch_seed,
+    )?;
+    let w = dominance.weight(DOMINANCE_BASE_WORK_SCORE, &solver, height);
+    let cand = RoleCandidate::from_assignment_v2(&proof, PenaltyStatus::Clean.id(), w, [role; 32]);
+    let cdg: [u8; 32] = {
+        let mut h = Sha256::new();
+        h.update(cand.serialize());
+        h.finalize().into()
+    };
+    let challenge = crate::poawx_puzzle::PuzzleChallengeV1::build(
+        network_id,
+        height,
+        role,
+        cand.solver_pkh,
+        cand.ticket_digest,
+        cand.assignment_proof_digest,
+        cdg,
+        prev_hash,
+        profile,
+    );
+    let sol = crate::poawx_puzzle::solve_dev(&challenge)
+        .ok_or_else(|| "worker: puzzle solve failed".to_string())?;
+
+    // The worker's own claim material, derived from its own key.
+    let mk = |tag: &[u8]| -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(b"IRIUM_ROLE_WORKER_CLAIM_V1");
+        h.update(tag);
+        h.update(worker_secret);
+        h.update(height.to_le_bytes());
+        h.update([role]);
+        h.finalize().into()
+    };
+    let secret = mk(b"secret");
+    let nonce = mk(b"nonce");
+    let ticket = crate::poawx_ticket::TicketProof::new(
+        network_id, height, prev_hash, role, solver, height, height + 100_000, apk,
+        [0x22u8; 32], PenaltyStatus::Clean.id(),
+    );
+    Ok(crate::poawx_role_bundle::RoleBundleV1 {
+        network_id,
+        target_height: height,
+        role_id: role,
+        solver_pkh: solver,
+        assignment_public_key: apk,
+        assignment_proof: proof,
+        ticket_proof: ticket,
+        puzzle_solution: sol,
+        lane_id: crate::poawx::assign_lane(network_id, height, &prev_hash, role, 0).id(),
+        claim_secret: secret,
+        claim_nonce: nonce,
+        commitment_hash: crate::poawx::role_precommit_commitment(&secret, &nonce),
+        claim_digest: [0u8; 32],
+    })
 }
 
 pub fn build_multi_participant_poawx_block_with_parent(

--- a/src/poawx_mining_harness.rs
+++ b/src/poawx_mining_harness.rs
@@ -217,6 +217,33 @@ pub struct AllGatesProof {
 /// The PoAW-X identities an all-gates block needs. `dev()` reproduces the fixed
 /// devnet keys (byte-identical to the original harness); `solo()` derives every
 /// role from a single miner secret so a real solo miner plays all roles.
+/// C3: per-role collected artifacts. Each is the PUBLIC material a role-worker
+/// produced and submitted over the collection channel -- never a private key.
+///
+/// The assignment proof and the puzzle solution MUST travel together: the puzzle
+/// challenge binds both `solver_pkh` and `assignment_proof_digest`, so a solution is
+/// only valid against the challenge derived from that exact proof.
+#[derive(Debug, Clone, Default)]
+pub struct CollectedArtifacts {
+    pub compute: Option<crate::poawx_role_bundle::RoleBundleV1>,
+    pub verify: Option<crate::poawx_role_bundle::RoleBundleV1>,
+    pub support: Option<crate::poawx_role_bundle::RoleBundleV1>,
+}
+
+impl CollectedArtifacts {
+    pub fn for_role(&self, role: u8) -> Option<&crate::poawx_role_bundle::RoleBundleV1> {
+        match role {
+            r if r == ROLE_COMPUTE_CONTRIBUTOR => self.compute.as_ref(),
+            r if r == ROLE_VERIFY_CONTRIBUTOR => self.verify.as_ref(),
+            r if r == ROLE_SUPPORT_CONTRIBUTOR => self.support.as_ref(),
+            _ => None,
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.compute.is_none() && self.verify.is_none() && self.support.is_none()
+    }
+}
+
 pub struct AllGatesIdentities {
     pub worker_sk: SigningKey,
     pub member_sk: SigningKey,
@@ -229,6 +256,12 @@ pub struct AllGatesIdentities {
     /// Base entropy for the deterministic per-(height,role) hidden-precommit claim
     /// secret/nonce. Identity-bound so H-1 commit and H reveal derive identically.
     pub claim_seed: [u8; 32],
+    /// C3: pre-made PUBLIC artifacts collected from foreign role-workers, per role.
+    /// When present for a role, the builder uses that worker's own assignment proof,
+    /// claim reveal material and puzzle solution instead of deriving them from a
+    /// secret it does not and must not hold. `None` everywhere => byte-identical to
+    /// the pre-C3 behaviour.
+    pub collected: Option<CollectedArtifacts>,
     /// Stage D Step 5 (delegated/mode-1): when Some, the receipt `worker_pkh` (the
     /// PRIMARY payout) is this value (the miner's payout pkh) instead of
     /// hash160(worker_sk pubkey). None => solo/dev (worker == payee).
@@ -263,6 +296,7 @@ impl AllGatesIdentities {
             verify_assign: [8u8; 32],
             support_assign: [9u8; 32],
             claim_seed: [0x2Au8; 32],
+            collected: None,
             worker_pkh_override: None,
             delegation: None,
             revocations: None,
@@ -300,6 +334,7 @@ impl AllGatesIdentities {
             verify_assign: *miner_secret,
             support_assign: *miner_secret,
             claim_seed: derive(b"claim"),
+            collected: None,
             worker_pkh_override: None,
             delegation: None,
             revocations: None,
@@ -311,6 +346,30 @@ impl AllGatesIdentities {
     /// solver_pkh == hash160(assignment_public_key) -- satisfying the new contributor-role
     /// binding rule. The worker plays PRIMARY; the SUPPORT participant is the finality
     /// member (support_solver == hash160(member pubkey), as the committee requires).
+    /// C3: a builder that pays COLLECTED foreign workers. It holds only its own
+    /// worker secret; every contributor role is supplied as public artifacts that
+    /// arrived over the collection channel. The per-role secrets are set to the
+    /// worker's own secret purely as unused placeholders -- with `collected` present
+    /// they are never used to prove anything, which is exactly the property this
+    /// constructor exists to establish.
+    pub fn with_collected(
+        worker_secret: &[u8; 32],
+        collected: CollectedArtifacts,
+    ) -> Result<Self, String> {
+        let mut me = Self::solo(worker_secret)?;
+        if let Some(b) = collected.compute.as_ref() {
+            me.compute_solver = b.solver_pkh;
+        }
+        if let Some(b) = collected.verify.as_ref() {
+            me.verify_solver = b.solver_pkh;
+        }
+        if let Some(b) = collected.support.as_ref() {
+            me.support_solver = b.solver_pkh;
+        }
+        me.collected = Some(collected);
+        Ok(me)
+    }
+
     pub fn multi_participant(
         worker_secret: &[u8; 32],
         compute_secret: &[u8; 32],
@@ -341,6 +400,7 @@ impl AllGatesIdentities {
             verify_assign: *verify_secret,
             support_assign: *support_secret,
             claim_seed: derive(b"claim"),
+            collected: None,
             worker_pkh_override: None,
             delegation: None,
             revocations: None,
@@ -390,6 +450,7 @@ impl AllGatesIdentities {
             verify_assign: derive(b"verify"),
             support_assign: derive(b"support"),
             claim_seed: derive(b"claim"),
+            collected: None,
             worker_pkh_override: Some(delegation.miner_pkh()),
             delegation: Some(delegation),
             revocations: if revocations.is_empty() {
@@ -470,6 +531,43 @@ pub fn build_solo_poawx_block(
 /// are performed by three DISTINCT participant keys (each role solver == hash160 of its own
 /// VRF key), so the block is valid under the active contributor-role binding rule.
 #[allow(clippy::too_many_arguments)]
+/// C3: build a block that pays COLLECTED foreign role-workers.
+///
+/// Note the signature: the ONLY secret is the builder's own `worker_secret`. Every
+/// contributor role arrives as public artifacts from the collection channel. This is
+/// the property the pre-C3 builders could not express -- they all required each
+/// worker's private key, which a real collector can never have.
+#[allow(clippy::too_many_arguments)]
+pub fn build_collected_poawx_block_with_parent(
+    worker_secret: &[u8; 32],
+    collected: CollectedArtifacts,
+    network_id: u8,
+    height: u64,
+    prev_hash: [u8; 32],
+    parent_prev_hash: Option<[u8; 32]>,
+    bits: u32,
+    time: u32,
+    receipt_difficulty_bits: u32,
+    parent_seed_components: ([u8; 32], [u8; 32]),
+) -> Result<AllGatesProof, String> {
+    build_all_gates_block_with(
+        &AllGatesIdentities::with_collected(worker_secret, collected)?,
+        network_id,
+        height,
+        prev_hash,
+        parent_prev_hash,
+        bits,
+        time,
+        receipt_difficulty_bits,
+        parent_seed_components,
+        None,
+        None,
+        None,
+        None,
+        &default_cpu_nonce_solver,
+    )
+}
+
 pub fn build_multi_participant_poawx_block_with_parent(
     worker_secret: &[u8; 32],
     compute_secret: &[u8; 32],
@@ -864,7 +962,18 @@ fn build_all_gates_block_with(
                        dom: &PersistentDominance|
      -> Result<([AssignmentProofV2; 3], [RoleCandidate; 3], CandidateSet), String> {
         let mk = |secret: &[u8; 32], role: u8, solver: [u8; 20], ticket: [u8; 32]| {
-            let p = AssignmentProofV2::prove(secret, net, th, role, solver, ticket, sd)?;
+            // C3: for a COLLECTED role use the worker's own proof verbatim. The builder
+            // holds no secret for that worker and must not fabricate a proof on its
+            // behalf -- the proof IS the worker's attributable work.
+            let collected_proof = ids
+                .collected
+                .as_ref()
+                .and_then(|c| c.for_role(role))
+                .map(|b| b.assignment_proof.clone());
+            let p = match collected_proof {
+                Some(p) => p,
+                None => AssignmentProofV2::prove(secret, net, th, role, solver, ticket, sd)?,
+            };
             let w = dom.weight(DOMINANCE_BASE_WORK_SCORE, &solver, th);
             let c = RoleCandidate::from_assignment_v2(&p, PenaltyStatus::Clean.id(), w, [role; 32]);
             Ok::<_, String>((p, c))
@@ -931,7 +1040,30 @@ fn build_all_gates_block_with(
             prev_hash,
             profile,
         );
-        sols.push(solve_dev(&challenge).ok_or_else(|| "harness: puzzle solve failed".to_string())?);
+        // C3: a COLLECTED role supplies its own solved puzzle. The challenge above is
+        // already bound to that worker's solver_pkh and assignment_proof_digest, so the
+        // worker's solution is the only one that can verify against it. Verified here
+        // rather than trusted -- a mismatch is an assembly error, not a silent bad block.
+        let collected_sol = ids
+            .collected
+            .as_ref()
+            .and_then(|c| c.for_role(role))
+            .map(|b| b.puzzle_solution);
+        let sol = match collected_sol {
+            Some(s) => {
+                match crate::poawx_puzzle::verify_solution(&challenge, &s) {
+                    crate::poawx_puzzle::PuzzleVerificationResult::Valid => s,
+                    other => {
+                        return Err(format!(
+                            "harness: collected puzzle solution for role {role} does not \
+                             verify against its challenge: {other:?}"
+                        ))
+                    }
+                }
+            }
+            None => solve_dev(&challenge).ok_or_else(|| "harness: puzzle solve failed".to_string())?,
+        };
+        sols.push(sol);
     }
 
     // SUPPORT-committee finality proof finalizing the parent (block_hash = prev_hash).
@@ -957,8 +1089,14 @@ fn build_all_gates_block_with(
     // THIS block's precommit_root from the block itself (miner-independent).
     let precommit_root = if hp_active {
         let leaf = |role: u8, solver: [u8; 20]| -> [u8; 32] {
-            let s = derive_claim_secret(&claim_seed, height, role);
-            let n = derive_claim_nonce(&claim_seed, height, role);
+            // Must mirror the reveal path exactly, including collected material.
+            let (s, n) = match ids.collected.as_ref().and_then(|c| c.for_role(role)) {
+                Some(b) => (b.claim_secret, b.claim_nonce),
+                None => (
+                    derive_claim_secret(&claim_seed, height, role),
+                    derive_claim_nonce(&claim_seed, height, role),
+                ),
+            };
             let c = crate::poawx::role_precommit_commitment(&s, &n);
             crate::poawx::role_precommit_leaf(net, height, role, &solver, &c)
         };
@@ -980,13 +1118,22 @@ fn build_all_gates_block_with(
         let lane = crate::poawx::assign_lane(net, height, &prev_hash, role, 0);
         // Hidden-precommit reveal: derived secret/nonce + hiding commitment when the
         // gate is active; legacy fixed values + None otherwise (byte-identical).
-        let (secret, nonce) = if hp_active {
-            (
+        // C3: a COLLECTED role reveals the worker's OWN claim material, so the
+        // commitment committed in precommit_root and the reveal in the receipt agree
+        // with what that worker actually computed. Deriving from the builder's
+        // claim_seed would commit to material the worker never produced.
+        let collected_claim = ids
+            .collected
+            .as_ref()
+            .and_then(|c| c.for_role(role))
+            .map(|b| (b.claim_secret, b.claim_nonce));
+        let (secret, nonce) = match (hp_active, collected_claim) {
+            (true, Some((s, n))) => (s, n),
+            (true, None) => (
                 derive_claim_secret(&claim_seed, height, role),
                 derive_claim_nonce(&claim_seed, height, role),
-            )
-        } else {
-            ([0x02u8; 32], [0x01u8; 32])
+            ),
+            (false, _) => ([0x02u8; 32], [0x01u8; 32]),
         };
         let cd = crate::poawx::role_claim_digest(
             net,

--- a/src/poawx_mining_harness.rs
+++ b/src/poawx_mining_harness.rs
@@ -636,6 +636,25 @@ pub fn simulate_role_worker_bundle(
         network_id, height, prev_hash, role, solver, height, height + 100_000, apk,
         [0x22u8; 32], PenaltyStatus::Clean.id(),
     );
+    // R4: SUPPORT doubles as the finality committee member, so it signs its OWN vote
+    // with the same key that owns its payout. The vote finalizes the PARENT
+    // (block_hash = prev_hash), so no knowledge of the block under construction is
+    // needed. Its ticket_digest is the worker's real ticket, keeping the bundle
+    // internally coherent.
+    let finality_vote = if role == ROLE_SUPPORT_CONTRIBUTOR {
+        Some(FinalityVoteV1::signed(
+            &sk,
+            network_id,
+            height,
+            prev_hash,
+            [0u8; 32],
+            0,
+            ticket.ticket_digest,
+            FinalityVoteType::Commit,
+        ))
+    } else {
+        None
+    };
     Ok(crate::poawx_role_bundle::RoleBundleV1 {
         network_id,
         target_height: height,
@@ -650,6 +669,7 @@ pub fn simulate_role_worker_bundle(
         claim_nonce: nonce,
         commitment_hash: crate::poawx::role_precommit_commitment(&secret, &nonce),
         claim_digest: [0u8; 32],
+        finality_vote,
     })
 }
 
@@ -1154,6 +1174,19 @@ fn build_all_gates_block_with(
     // SUPPORT-committee finality proof finalizing the parent (block_hash = prev_hash).
     let (num, den) = finality_threshold();
     let mut fproof = FinalityProofV1::new(net, height, prev_hash, [0u8; 32], 0, num, den);
+    // R4: when SUPPORT is COLLECTED, the committee member is that worker, not the
+    // builder, and the builder holds no key for it. Use the worker's own signed vote
+    // verbatim -- reconstructing it is impossible and re-signing it with member_sk
+    // would produce a vote from a non-committee member, which is exactly how the C3
+    // proof first failed.
+    if let Some(v) = ids
+        .collected
+        .as_ref()
+        .and_then(|c| c.for_role(ROLE_SUPPORT_CONTRIBUTOR))
+        .and_then(|b| b.finality_vote.clone())
+    {
+        fproof.push(v);
+    } else {
     fproof.push(FinalityVoteV1::signed(
         member_sk,
         net,
@@ -1164,6 +1197,7 @@ fn build_all_gates_block_with(
         [0x11u8; 32],
         FinalityVoteType::Commit,
     ));
+    }
     fproof.sort_canonical();
 
     // Fix A1: hidden-precommit root committing THIS block's OWN role-claim leaves

--- a/src/poawx_mining_harness.rs
+++ b/src/poawx_mining_harness.rs
@@ -1650,4 +1650,153 @@ mod tests {
             "builder accepts known mainnet network id"
         );
     }
+
+    // ── Role-worker / builder dominance-weight agreement (height-2 fix) ───────────
+    //
+    // Shared setup for the two puzzle-challenge tests below: a real assignment proof, a
+    // dominance state in which the solver was already rewarded once (so its weight at the
+    // NEXT height falls below the empty baseline of 1000), and the pieces both the worker
+    // and the collected-builder feed into the per-role puzzle challenge.
+    fn dominance_weight_fixture(
+    ) -> (AssignmentProofV2, [u8; 20], u64, u64, [u8; 32], crate::poawx_puzzle::PuzzleDifficultyProfile)
+    {
+        let net = 0u8;
+        let height = 2u64;
+        let role = ROLE_COMPUTE_CONTRIBUTOR;
+        let secret = [7u8; 32];
+        let seed = [0x33u8; 32];
+        let a_ticket = [0x11u8 + role; 32];
+        let proof = AssignmentProofV2::prove_self_solver(&secret, net, height, role, a_ticket, seed)
+            .expect("assignment proof");
+        let solver_pkh = proof.solver_pkh;
+
+        // Node-authoritative dominance: credit the solver a reward at height 1 so that at
+        // height 2 it carries recent reward share and its fairness weight is below 1000.
+        let mut node_dom = PersistentDominance::from_env();
+        node_dom.apply_event(solver_pkh, RoleRewardKind::Compute, block_reward(1), 1);
+        let node_weight = node_dom.weight(DOMINANCE_BASE_WORK_SCORE, &solver_pkh, height);
+
+        // The worker parses the SAME snapshot the endpoint ships (dominance_bytes ==
+        // to_bytes) and must derive the identical weight -- this is the round-trip lock.
+        let snapshot = node_dom.to_bytes();
+        let worker_dom = PersistentDominance::from_bytes(&snapshot).expect("snapshot round-trip");
+        assert_eq!(
+            worker_dom.to_bytes(),
+            snapshot,
+            "dominance snapshot round-trips through from_bytes byte-identically"
+        );
+        let worker_weight = worker_dom.weight(DOMINANCE_BASE_WORK_SCORE, &solver_pkh, height);
+        assert_eq!(
+            worker_weight, node_weight,
+            "worker-computed weight (from the shipped snapshot) equals the node weight"
+        );
+        assert!(
+            node_weight < 1000,
+            "a previously-rewarded solver's weight is below the empty baseline at height >= 2 (got {node_weight})"
+        );
+
+        let profile = crate::poawx_puzzle::profile_with_bits(8);
+        (proof, solver_pkh, node_weight, height as u64, [0x55u8; 32], profile)
+    }
+
+    fn role_puzzle_challenge(
+        proof: &AssignmentProofV2,
+        weight: u64,
+        height: u64,
+        prev_hash: [u8; 32],
+        profile: crate::poawx_puzzle::PuzzleDifficultyProfile,
+    ) -> PuzzleChallengeV1 {
+        let role = ROLE_COMPUTE_CONTRIBUTOR;
+        let cand =
+            RoleCandidate::from_assignment_v2(proof, PenaltyStatus::Clean.id(), weight, [role; 32]);
+        let cdg: [u8; 32] = {
+            let mut h = Sha256::new();
+            h.update(cand.serialize());
+            h.finalize().into()
+        };
+        PuzzleChallengeV1::build(
+            0,
+            height,
+            role,
+            cand.solver_pkh,
+            cand.ticket_digest,
+            cand.assignment_proof_digest,
+            cdg,
+            prev_hash,
+            profile,
+        )
+    }
+
+    #[test]
+    fn worker_and_builder_agree_on_puzzle_challenge_at_height_two() {
+        // The fix: with the node-authoritative dominance weight on BOTH sides, the worker's
+        // solved puzzle verifies against the builder's rebuilt challenge at height >= 2.
+        let (proof, _pkh, node_weight, height, prev, profile) = dominance_weight_fixture();
+        let worker_challenge = role_puzzle_challenge(&proof, node_weight, height, prev, profile);
+        let builder_challenge = role_puzzle_challenge(&proof, node_weight, height, prev, profile);
+        let worker_sol = solve_dev(&worker_challenge).expect("worker solves its puzzle");
+        match crate::poawx_puzzle::verify_solution(&builder_challenge, &worker_sol) {
+            crate::poawx_puzzle::PuzzleVerificationResult::Valid => {}
+            other => panic!("expected Valid against the builder's challenge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hardcoded_weight_breaks_puzzle_verification_at_height_two() {
+        // Prove-the-break: the OLD behaviour (candidate built with the hardcoded 1000) yields
+        // a different candidate digest than the node-weight candidate at height >= 2, so the
+        // worker's solution against its 1000-challenge fails against the builder's real
+        // challenge with exactly the "proof digest mismatch" we observed on devnet-mp.
+        let (proof, _pkh, node_weight, height, prev, profile) = dominance_weight_fixture();
+        assert_ne!(node_weight, 1000, "fixture must have a non-baseline weight to be meaningful");
+        let broken_challenge = role_puzzle_challenge(&proof, 1000, height, prev, profile);
+        let builder_challenge = role_puzzle_challenge(&proof, node_weight, height, prev, profile);
+        let broken_sol = solve_dev(&broken_challenge).expect("worker solves its (wrong) puzzle");
+        match crate::poawx_puzzle::verify_solution(&builder_challenge, &broken_sol) {
+            crate::poawx_puzzle::PuzzleVerificationResult::Invalid(m) => {
+                assert!(m.contains("proof digest mismatch"), "unexpected reason: {m}")
+            }
+            other => panic!("expected Invalid(proof digest mismatch), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn seed_non_divergence_endpoint_matches_builder_at_height_two() {
+        // Lock that the /poawx/role-work seed (expected_epoch_seed) and the collected-builder's
+        // reconstruction (admission_epoch_seed grandparent base + seed_components_from_block,
+        // which is exactly what /rpc/block emits) are the SAME seed for a real parent block at
+        // height >= 2. This documents that the seed was never the divergence and stops a future
+        // refactor from silently reintroducing a real split.
+        use crate::poawx_committed_admission::{
+            expected_epoch_seed, multisource_seed_active, resolve_epoch_seed_parts_with,
+            seed_components_from_block,
+        };
+        let parent = build_devnet_all_gates_block(0, 1, [0x44u8; 32], None, 0x207fffff, 1, 1)
+            .expect("build a real devnet parent block")
+            .block;
+        let prev = parent.header.hash_for_height(1); // the prev_hash for height 2
+        let (fin, pre) = seed_components_from_block(Some(&parent));
+        assert!(
+            fin != [0u8; 32] || pre != [0u8; 32],
+            "a real parent block contributes nonzero seed components"
+        );
+
+        let h = 2u64;
+        let gate = multisource_seed_active(h);
+        let endpoint_seed = expected_epoch_seed(h, prev, Some(&parent));
+        let builder_base = admission_epoch_seed(Some(parent.header.prev_hash), prev);
+        let builder_seed = resolve_epoch_seed_parts_with(gate, h, builder_base, fin, pre);
+        assert_eq!(
+            endpoint_seed, builder_seed,
+            "endpoint and builder derive an identical seed at height 2 -- the seed is not the divergence"
+        );
+
+        // When the multi-source gate is active, the parent's components genuinely change the
+        // seed away from the legacy base -- both sides just compute that change identically.
+        assert_ne!(
+            resolve_epoch_seed_parts_with(true, h, builder_base, fin, pre),
+            builder_base,
+            "with multisource active a real parent's components change the seed"
+        );
+    }
 }

--- a/src/poawx_role_bundle.rs
+++ b/src/poawx_role_bundle.rs
@@ -245,6 +245,32 @@ impl NodeRoleBundlePool {
         }
     }
 
+    /// R1: the full tiered path. `src` is the submitting source. Ordering is asserted
+    /// by `tier1_rejection_never_reaches_validation`.
+    pub fn ingest_tiered(
+        &self,
+        src: std::net::IpAddr,
+        bundle: RoleBundleV1,
+        expected_network: u8,
+        expected_height: u64,
+        expected_seed: Option<[u8; 32]>,
+    ) -> Result<BundleOutcome, String> {
+        // TIER 1 -- per source. Cheap, and it runs BEFORE validation so that the cost of
+        // validating is itself protected.
+        if !crate::poawx_admission::admission_rate_allowed(src) {
+            return Err("role bundle: source rate limited".to_string());
+        }
+        // TIER 2 -- validation. Counted so a test can prove tier 1 short-circuits it.
+        VALIDATIONS_PERFORMED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        bundle.validate(expected_network, expected_height, expected_seed)?;
+        // TIER 3 -- per identity, only ever reached by an identity that already cost a
+        // real ECVRF prove.
+        if !identity_rate_allowed(&bundle.solver_pkh) {
+            return Err("role bundle: identity rate limited".to_string());
+        }
+        self.ingest(bundle, expected_network, expected_height, expected_seed)
+    }
+
     pub fn ingest_json(
         &self,
         json: &str,
@@ -309,6 +335,71 @@ impl NodeRoleBundlePool {
     }
 }
 
+// ── R1: per-identity rate limiting (tier 3) ─────────────────────────────────
+//
+// TIER ORDERING IS THE DESIGN, and reversing it defeats the purpose:
+//   1. per-SOURCE (cheap)   -- guards the cost of validation itself
+//   2. VALIDATE             -- recompute the payout binding, verify the ECVRF
+//   3. per-IDENTITY         -- guards POOL SLOTS, and only ever sees identities that
+//                              already cost a real ECVRF prove (~1089us measured on
+//                              this host), so minting identities is not free
+//
+// Limiting by identity FIRST would be useless: garbage carries no valid solver_pkh, so
+// the identity limiter would never engage and validation would become the DoS surface.
+// Validating first without a source gate makes validation itself the attack.
+//
+// This also resolves the aggregator caveat carried from A1: a pool relaying for 500
+// miners is ONE source but 500 identities, so it needs headroom at tier 1 while tier 3
+// keeps any single worker from monopolising pool slots.
+
+const IDENTITY_RATE_WINDOW_SECS: u64 = 60;
+const IDENTITY_RATE_MAX: u32 = 8;
+
+struct IdentityRate {
+    window_start: std::time::Instant,
+    count: u32,
+}
+
+fn identity_rate_map() -> &'static Mutex<BTreeMap<[u8; 20], IdentityRate>> {
+    static M: OnceLock<Mutex<BTreeMap<[u8; 20], IdentityRate>>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Monotonic (`Instant`) sliding window per identity. Deliberately NOT the generic
+/// `rate_limiter::RateLimiter`, which is keyed on wall-clock `SystemTime` -- a clock
+/// jump would reset every bucket.
+pub fn identity_rate_allowed(solver_pkh: &[u8; 20]) -> bool {
+    let now = std::time::Instant::now();
+    let window = std::time::Duration::from_secs(IDENTITY_RATE_WINDOW_SECS);
+    let mut m = identity_rate_map().lock().unwrap_or_else(|e| e.into_inner());
+    if m.len() > 8192 {
+        m.retain(|_, r| now.duration_since(r.window_start) < window);
+    }
+    let e = m.entry(*solver_pkh).or_insert(IdentityRate {
+        window_start: now,
+        count: 0,
+    });
+    if now.duration_since(e.window_start) >= window {
+        e.window_start = now;
+        e.count = 0;
+    }
+    e.count = e.count.saturating_add(1);
+    e.count <= IDENTITY_RATE_MAX
+}
+
+/// Test observability: how many times a bundle actually reached VALIDATION. Lets a test
+/// assert that a tier-1 rejection never paid the validation cost, rather than inferring it.
+pub static VALIDATIONS_PERFORMED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// R2: whether the submission endpoint accepts non-loopback sources. Default OFF --
+/// an operator must deliberately opt in. Ships inert.
+pub fn role_bundle_public_submission_enabled() -> bool {
+    std::env::var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC")
+        .map(|v| v.trim() == "1")
+        .unwrap_or(false)
+}
+
 static GLOBAL_ROLE_BUNDLE_POOL: OnceLock<NodeRoleBundlePool> = OnceLock::new();
 
 pub fn global_role_bundle_pool() -> &'static NodeRoleBundlePool {
@@ -359,7 +450,7 @@ mod tests {
 
     /// Build a genuinely valid bundle for `secret` in `role`, in the exact JSON shape
     /// `poawx-role-worker` emits, so the fixture exercises the real parser.
-    fn bundle_json(secret_byte: u8, role: u8) -> String {
+    pub(super) fn bundle_json(secret_byte: u8, role: u8) -> String {
         bundle_json_at(secret_byte, role, H)
     }
 
@@ -506,5 +597,121 @@ mod tests {
         let c = collect_roles_for_height(u64::MAX); // nothing ever ingested at this height
         assert!(c.is_empty());
         assert_eq!(c.distinct_payees(), 0);
+    }
+}
+
+#[cfg(test)]
+mod r1_r2_r3_tests {
+    use super::*;
+    use crate::poawx::ROLE_COMPUTE_CONTRIBUTOR;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::atomic::Ordering;
+
+    const NET: u8 = 2;
+    const H: u64 = 42;
+    const SEED: [u8; 32] = [0x5Au8; 32];
+
+    fn ip(n: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, n))
+    }
+
+    fn valid_bundle(secret_byte: u8) -> RoleBundleV1 {
+        RoleBundleV1::from_json(&super::tests::bundle_json(
+            secret_byte,
+            ROLE_COMPUTE_CONTRIBUTOR,
+        ))
+        .expect("parse")
+    }
+
+    /// R1 ORDERING -- the load-bearing property. A tier-1 (source) rejection must
+    /// short-circuit BEFORE validation, so a flood never buys an ECVRF verify. Asserted
+    /// directly against a validation counter rather than inferred from timing.
+    #[test]
+    fn tier1_rejection_never_reaches_validation() {
+        let pool = NodeRoleBundlePool::default();
+        let src = ip(11);
+        let b = valid_bundle(0x21);
+        // Exhaust tier 1 for this source.
+        let mut exhausted = false;
+        for _ in 0..10_000 {
+            if pool
+                .ingest_tiered(src, b.clone(), NET, H, Some(SEED))
+                .err()
+                .map(|e| e.contains("source rate limited"))
+                .unwrap_or(false)
+            {
+                exhausted = true;
+                break;
+            }
+        }
+        assert!(exhausted, "tier 1 never engaged; the limiter is not wired");
+        // With tier 1 now rejecting, validation must NOT run.
+        let before = VALIDATIONS_PERFORMED.load(Ordering::Relaxed);
+        let err = pool
+            .ingest_tiered(src, b, NET, H, Some(SEED))
+            .expect_err("must still be source-limited");
+        assert!(err.contains("source rate limited"), "got: {err}");
+        assert_eq!(
+            VALIDATIONS_PERFORMED.load(Ordering::Relaxed),
+            before,
+            "a tier-1 rejection paid for validation -- the tiers are in the wrong order"
+        );
+    }
+
+    /// R1 INDEPENDENCE -- the identity limiter must bite even when every request comes
+    /// from a FRESH source, which is exactly the aggregator case: one pool relaying for
+    /// many workers, or one worker spread across many addresses.
+    #[test]
+    fn identity_limit_engages_independently_of_source_limit() {
+        let pool = NodeRoleBundlePool::default();
+        let b = valid_bundle(0x22);
+        let mut identity_limited = false;
+        // A different source every time, so tier 1 is always fresh.
+        for i in 0..(IDENTITY_RATE_MAX + 4) {
+            let r = pool.ingest_tiered(ip(100 + i as u8), b.clone(), NET, H, Some(SEED));
+            if let Err(e) = r {
+                if e.contains("identity rate limited") {
+                    identity_limited = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            identity_limited,
+            "identity limiting never engaged across distinct sources -- one identity can \
+             monopolise pool slots by rotating addresses"
+        );
+    }
+
+    /// The identity limiter must be per identity, not global: a DIFFERENT worker is
+    /// unaffected by another's exhaustion.
+    #[test]
+    fn identity_limit_is_per_identity_not_global() {
+        let pool = NodeRoleBundlePool::default();
+        let noisy = valid_bundle(0x23);
+        for i in 0..(IDENTITY_RATE_MAX + 4) {
+            let _ = pool.ingest_tiered(ip(150 + i as u8), noisy.clone(), NET, H, Some(SEED));
+        }
+        let quiet = valid_bundle(0x24);
+        let r = pool.ingest_tiered(ip(200), quiet, NET, H, Some(SEED));
+        assert!(
+            !matches!(&r, Err(e) if e.contains("identity rate limited")),
+            "a quiet worker was limited because a different one flooded: {r:?}"
+        );
+    }
+
+    /// R2 -- public submission is OFF unless an operator opts in. Default loopback.
+    #[test]
+    fn public_submission_defaults_off_and_is_opt_in() {
+        std::env::remove_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC");
+        assert!(
+            !role_bundle_public_submission_enabled(),
+            "public submission must default OFF"
+        );
+        std::env::set_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC", "1");
+        assert!(role_bundle_public_submission_enabled());
+        std::env::set_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC", "0");
+        assert!(!role_bundle_public_submission_enabled(), "only \"1\" enables it");
+        std::env::remove_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC");
     }
 }

--- a/src/poawx_role_bundle.rs
+++ b/src/poawx_role_bundle.rs
@@ -147,6 +147,33 @@ impl RoleBundleV1 {
         })
     }
 
+    /// Inverse of `from_json` (round-trips). Used by the dev-only collected-bundles
+    /// endpoint so a genuinely SEPARATE proposer process can rebuild the block from the
+    /// pool's validated bundles without holding any worker's key. Non-mainnet/test use.
+    pub fn to_json(&self) -> String {
+        let mut o = serde_json::json!({
+            "network_id": self.network_id,
+            "target_height": self.target_height,
+            "role_id": self.role_id,
+            "solver_pkh": hex::encode(self.solver_pkh),
+            "assignment_public_key": hex::encode(self.assignment_public_key),
+            "assignment_proof": hex::encode(self.assignment_proof.serialize()),
+            "ticket_proof": hex::encode(self.ticket_proof.serialize()),
+            "puzzle_solution": hex::encode(self.puzzle_solution.serialize()),
+            "claim": {
+                "lane_id": self.lane_id,
+                "secret": hex::encode(self.claim_secret),
+                "nonce": hex::encode(self.claim_nonce),
+                "commitment_hash": hex::encode(self.commitment_hash),
+                "claim_digest": hex::encode(self.claim_digest),
+            },
+        });
+        if let Some(v) = &self.finality_vote {
+            o["finality_vote"] = serde_json::Value::String(hex::encode(v.serialize()));
+        }
+        serde_json::to_string(&o).unwrap()
+    }
+
     /// The self-VRF score used to resolve competition between workers for one role,
     /// matching `best_for_role`'s ordering.
     pub fn score(&self) -> u64 {

--- a/src/poawx_role_bundle.rs
+++ b/src/poawx_role_bundle.rs
@@ -1,0 +1,510 @@
+//! C1/C2/C3 — the role-worker bundle collection channel.
+//!
+//! A contributor role-worker (COMPUTE / VERIFY / SUPPORT) performs its assigned work
+//! independently, bound to its OWN payout key, and emits a bundle. Until now the only
+//! transport for that bundle was a human copying JSON files into `IRIUM_M3_DIR` for the
+//! `#[ignore]`d rig tests. This module is the actual channel.
+//!
+//! TRANSPORT CHOICE: node-local RPC, not gossip and not the mempool.
+//!  - Mempool semantics are wrong: a bundle is bound to exactly one `target_height` and
+//!    is worthless at H+1, whereas the mempool persists until inclusion.
+//!  - Gossip would be wasteful (a bundle is only useful to whoever builds the NEXT
+//!    block, not to 100 peers) and would create exactly the unauthenticated remote
+//!    ingest surface that produced the registration-pool defects.
+//!  - RPC mirrors the existing proposer-registration bridge: worker -> node -> pool ->
+//!    block template. No new wire message, no protocol change, no activation.
+//!
+//! VALIDATED ON INGEST, NOT ON USE. Every bundle is fully verified when it arrives:
+//! the payout binding is recomputed rather than trusted, and the ECVRF proof is checked.
+//! The registration pool's sybil check trusted an attacker-supplied digest field and so
+//! provided no protection at all; that mistake is not repeated here.
+//!
+//! SCOPE / KNOWN LIMITATION: the RPC route this pool serves is LOOPBACK-ONLY in this
+//! unit. Co-located miners (standalone CLI, GPU, Irium Core with a bundled node) can
+//! submit; a POOL-based miner submitting to a remote pool node CANNOT yet. Remote
+//! exposure is a deliberately separate, separately-approved unit. Do not read this as
+//! "all mining paths are now collected".
+#![allow(dead_code)]
+
+use ripemd::Ripemd160;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::poawx_candidate::AssignmentProofV2;
+use crate::poawx_puzzle::PuzzleSolutionV1;
+use crate::poawx_ticket::TicketProof;
+
+/// Hard bound on pooled bundles. Small: bundles are height-scoped and pruned, and only
+/// the best per (role, height) is ever retained.
+pub const ROLE_BUNDLE_POOL_MAX: usize = 512;
+
+/// Contributor roles that may submit a bundle. ROLE_PROPOSER is deliberately excluded:
+/// the proposer is the block builder, not a collected contributor.
+pub fn is_collectable_role(role_id: u8) -> bool {
+    role_id == crate::poawx::ROLE_COMPUTE_CONTRIBUTOR
+        || role_id == crate::poawx::ROLE_VERIFY_CONTRIBUTOR
+        || role_id == crate::poawx::ROLE_SUPPORT_CONTRIBUTOR
+}
+
+fn hash160(bytes: &[u8]) -> [u8; 20] {
+    let mut o = [0u8; 20];
+    o.copy_from_slice(&Ripemd160::digest(Sha256::digest(bytes)));
+    o
+}
+
+/// A collected role-worker bundle. Field-for-field the JSON that `poawx-role-worker`
+/// already emits, so existing workers and existing rig fixtures are compatible.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RoleBundleV1 {
+    pub network_id: u8,
+    pub target_height: u64,
+    pub role_id: u8,
+    pub solver_pkh: [u8; 20],
+    pub assignment_public_key: [u8; 33],
+    pub assignment_proof: AssignmentProofV2,
+    pub ticket_proof: TicketProof,
+    pub puzzle_solution: PuzzleSolutionV1,
+    pub lane_id: u8,
+    pub claim_secret: [u8; 32],
+    pub claim_nonce: [u8; 32],
+    pub commitment_hash: [u8; 32],
+    pub claim_digest: [u8; 32],
+}
+
+fn hex_field(v: &serde_json::Value, k: &str) -> Result<Vec<u8>, String> {
+    let s = v
+        .get(k)
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| format!("role bundle: missing field {k}"))?;
+    hex::decode(s).map_err(|e| format!("role bundle: field {k} not hex: {e}"))
+}
+
+fn fixed<const N: usize>(b: Vec<u8>, k: &str) -> Result<[u8; N], String> {
+    if b.len() != N {
+        return Err(format!(
+            "role bundle: field {k} wrong length {} (want {N})",
+            b.len()
+        ));
+    }
+    let mut o = [0u8; N];
+    o.copy_from_slice(&b);
+    Ok(o)
+}
+
+impl RoleBundleV1 {
+    pub fn from_json(s: &str) -> Result<Self, String> {
+        let v: serde_json::Value =
+            serde_json::from_str(s).map_err(|e| format!("role bundle: bad json: {e}"))?;
+        let u64f = |k: &str| -> Result<u64, String> {
+            v.get(k)
+                .and_then(|x| x.as_u64())
+                .ok_or_else(|| format!("role bundle: missing/!u64 field {k}"))
+        };
+        let claim = v
+            .get("claim")
+            .ok_or_else(|| "role bundle: missing claim".to_string())?;
+        Ok(Self {
+            network_id: u64f("network_id")? as u8,
+            target_height: u64f("target_height")?,
+            role_id: u64f("role_id")? as u8,
+            solver_pkh: fixed::<20>(hex_field(&v, "solver_pkh")?, "solver_pkh")?,
+            assignment_public_key: fixed::<33>(
+                hex_field(&v, "assignment_public_key")?,
+                "assignment_public_key",
+            )?,
+            assignment_proof: AssignmentProofV2::deserialize(&hex_field(&v, "assignment_proof")?)?,
+            ticket_proof: TicketProof::deserialize(&hex_field(&v, "ticket_proof")?)?,
+            puzzle_solution: PuzzleSolutionV1::deserialize(&hex_field(&v, "puzzle_solution")?)?,
+            lane_id: claim
+                .get("lane_id")
+                .and_then(|x| x.as_u64())
+                .ok_or_else(|| "role bundle: missing claim.lane_id".to_string())?
+                as u8,
+            claim_secret: fixed::<32>(hex_field(claim, "secret")?, "claim.secret")?,
+            claim_nonce: fixed::<32>(hex_field(claim, "nonce")?, "claim.nonce")?,
+            commitment_hash: fixed::<32>(
+                hex_field(claim, "commitment_hash")?,
+                "claim.commitment_hash",
+            )?,
+            claim_digest: fixed::<32>(hex_field(claim, "claim_digest")?, "claim.claim_digest")?,
+        })
+    }
+
+    /// The self-VRF score used to resolve competition between workers for one role,
+    /// matching `best_for_role`'s ordering.
+    pub fn score(&self) -> u64 {
+        self.assignment_proof.score()
+    }
+
+    /// Full validation. Every check recomputes rather than trusting a declared field.
+    ///
+    /// `expected_seed` is checked when supplied; a collector that does not yet know the
+    /// epoch seed may pass `None` and still get every other guarantee.
+    pub fn validate(
+        &self,
+        expected_network: u8,
+        expected_height: u64,
+        expected_seed: Option<[u8; 32]>,
+    ) -> Result<(), String> {
+        if self.network_id != expected_network {
+            return Err("role bundle: wrong network".to_string());
+        }
+        if self.target_height != expected_height {
+            return Err("role bundle: wrong height".to_string());
+        }
+        if !is_collectable_role(self.role_id) {
+            return Err("role bundle: role is not a collectable contributor role".to_string());
+        }
+        // THE PAYOUT BINDING. Recomputed, never trusted. This is the rule
+        // `contributor_role_binding` enforces on-chain; a bundle failing it can never be
+        // paid, so it is rejected at ingest regardless of whether the gate is active.
+        if self.solver_pkh != hash160(&self.assignment_public_key) {
+            return Err("role bundle: solver pkh not derived from assignment key".to_string());
+        }
+        // The proof must be for THIS worker, THIS role.
+        if self.assignment_proof.solver_pkh != self.solver_pkh {
+            return Err("role bundle: assignment proof solver pkh mismatch".to_string());
+        }
+        if self.assignment_proof.assignment_public_key != self.assignment_public_key {
+            return Err("role bundle: assignment proof key mismatch".to_string());
+        }
+        if self.assignment_proof.role_id != self.role_id {
+            return Err("role bundle: assignment proof role mismatch".to_string());
+        }
+        if let Some(seed) = expected_seed {
+            if self.assignment_proof.seed != seed {
+                return Err("role bundle: assignment proof wrong seed".to_string());
+            }
+        }
+        // The ECVRF proof itself (checks version/network/height/digest and the curve op).
+        self.assignment_proof
+            .validate(expected_network, expected_height)
+            .map_err(|e| format!("role bundle: {e}"))?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BundleOutcome {
+    /// First bundle seen for this (height, role).
+    AcceptedNew,
+    /// Replaced a lower-scoring bundle for the same (height, role).
+    ReplacedLower,
+    /// Ignored: an equal-or-better bundle for this (height, role) is already held.
+    Duplicate,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Only bundles for this height are retained; advancing prunes everything older.
+    height: u64,
+    best: BTreeMap<(u8, [u8; 20]), RoleBundleV1>,
+}
+
+/// Node-local, height-scoped pool of validated contributor bundles.
+#[derive(Default)]
+pub struct NodeRoleBundlePool {
+    inner: Mutex<Inner>,
+}
+
+impl NodeRoleBundlePool {
+    /// Validate and pool a bundle. Rejection reasons are returned verbatim so the RPC
+    /// layer can surface a specific cause rather than a generic failure.
+    pub fn ingest(
+        &self,
+        bundle: RoleBundleV1,
+        expected_network: u8,
+        expected_height: u64,
+        expected_seed: Option<[u8; 32]>,
+    ) -> Result<BundleOutcome, String> {
+        bundle.validate(expected_network, expected_height, expected_seed)?;
+        let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if expected_height > g.height {
+            g.height = expected_height;
+            g.best.clear(); // height advanced: previous-height bundles are worthless
+        } else if expected_height < g.height {
+            return Err("role bundle: stale height".to_string());
+        }
+        if g.best.len() >= ROLE_BUNDLE_POOL_MAX
+            && !g.best.contains_key(&(bundle.role_id, bundle.solver_pkh))
+        {
+            return Err("role bundle: pool full".to_string());
+        }
+        let key = (bundle.role_id, bundle.solver_pkh);
+        match g.best.get(&key) {
+            Some(existing) if existing.score() >= bundle.score() => Ok(BundleOutcome::Duplicate),
+            Some(_) => {
+                g.best.insert(key, bundle);
+                Ok(BundleOutcome::ReplacedLower)
+            }
+            None => {
+                g.best.insert(key, bundle);
+                Ok(BundleOutcome::AcceptedNew)
+            }
+        }
+    }
+
+    pub fn ingest_json(
+        &self,
+        json: &str,
+        expected_network: u8,
+        expected_height: u64,
+        expected_seed: Option<[u8; 32]>,
+    ) -> Result<BundleOutcome, String> {
+        let b = RoleBundleV1::from_json(json)?;
+        self.ingest(b, expected_network, expected_height, expected_seed)
+    }
+
+    /// Highest-scoring collected bundle for `role_id` at the pool's current height.
+    /// Mirrors `best_for_role`'s ordering so collection and on-chain selection agree.
+    pub fn best_for_role(&self, role_id: u8, height: u64) -> Option<RoleBundleV1> {
+        let g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if g.height != height {
+            return None;
+        }
+        g.best
+            .iter()
+            .filter(|((r, _), _)| *r == role_id)
+            .map(|(_, b)| b)
+            .max_by_key(|b| b.score())
+            .cloned()
+    }
+
+    /// Every bundle held for `height`, for template exposure.
+    pub fn collected_for_height(&self, height: u64) -> Vec<RoleBundleV1> {
+        let g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if g.height != height {
+            return Vec::new();
+        }
+        g.best.values().cloned().collect()
+    }
+
+    /// Drop everything below `height`.
+    pub fn prune_below(&self, height: u64) {
+        let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if g.height < height {
+            g.height = height;
+            g.best.clear();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .best
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn current_height(&self) -> u64 {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .height
+    }
+}
+
+static GLOBAL_ROLE_BUNDLE_POOL: OnceLock<NodeRoleBundlePool> = OnceLock::new();
+
+pub fn global_role_bundle_pool() -> &'static NodeRoleBundlePool {
+    GLOBAL_ROLE_BUNDLE_POOL.get_or_init(NodeRoleBundlePool::default)
+}
+
+/// C3: the assembled contributor set a builder would use — the best collected worker
+/// for each contributor role at `height`. Returns `None` for a role with no collected
+/// bundle, so a builder can fall back to its own identity for that role and remain
+/// byte-identical to today's behaviour when nothing has been collected.
+#[derive(Debug, Clone, Default)]
+pub struct CollectedRoles {
+    pub compute: Option<RoleBundleV1>,
+    pub verify: Option<RoleBundleV1>,
+    pub support: Option<RoleBundleV1>,
+}
+
+impl CollectedRoles {
+    pub fn distinct_payees(&self) -> usize {
+        let mut s = std::collections::BTreeSet::new();
+        for b in [&self.compute, &self.verify, &self.support].into_iter().flatten() {
+            s.insert(b.solver_pkh);
+        }
+        s.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.compute.is_none() && self.verify.is_none() && self.support.is_none()
+    }
+}
+
+pub fn collect_roles_for_height(height: u64) -> CollectedRoles {
+    let p = global_role_bundle_pool();
+    CollectedRoles {
+        compute: p.best_for_role(crate::poawx::ROLE_COMPUTE_CONTRIBUTOR, height),
+        verify: p.best_for_role(crate::poawx::ROLE_VERIFY_CONTRIBUTOR, height),
+        support: p.best_for_role(crate::poawx::ROLE_SUPPORT_CONTRIBUTOR, height),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::poawx::{ROLE_COMPUTE_CONTRIBUTOR, ROLE_SUPPORT_CONTRIBUTOR, ROLE_VERIFY_CONTRIBUTOR};
+
+    const NET: u8 = 2; // devnet
+    const H: u64 = 42;
+    const SEED: [u8; 32] = [0x5Au8; 32];
+
+    /// Build a genuinely valid bundle for `secret` in `role`, in the exact JSON shape
+    /// `poawx-role-worker` emits, so the fixture exercises the real parser.
+    fn bundle_json(secret_byte: u8, role: u8) -> String {
+        bundle_json_at(secret_byte, role, H)
+    }
+
+    fn bundle_json_at(secret_byte: u8, role: u8, height: u64) -> String {
+        let secret = [secret_byte; 32];
+        let proof = AssignmentProofV2::prove_self_solver(&secret, NET, height, role, [0u8; 32], SEED)
+            .expect("prove");
+        let pkh = proof.solver_pkh;
+        let apk = proof.assignment_public_key;
+        let ticket = TicketProof::new(
+            NET, height, [0x11u8; 32], role, pkh, height, height + 100, apk, [0x22u8; 32], 0,
+        );
+        let sol = PuzzleSolutionV1 { mode: 0, nonce: 7, proof_digest: [0x33u8; 32] };
+        serde_json::json!({
+            "network_id": NET, "target_height": height, "role_id": role, "role": "compute",
+            "solver_pkh": hex::encode(pkh),
+            "assignment_public_key": hex::encode(apk),
+            "assignment_proof": hex::encode(proof.serialize()),
+            "ticket_proof": hex::encode(ticket.serialize()),
+            "puzzle_solution": hex::encode(sol.serialize()),
+            "claim": {
+                "lane_id": 1u8,
+                "secret": hex::encode([0x44u8; 32]),
+                "nonce": hex::encode([0x55u8; 32]),
+                "commitment_hash": hex::encode([0x66u8; 32]),
+                "claim_digest": hex::encode([0x77u8; 32]),
+            },
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn valid_bundle_parses_and_validates() {
+        let b = RoleBundleV1::from_json(&bundle_json(0x01, ROLE_COMPUTE_CONTRIBUTOR)).expect("parse");
+        b.validate(NET, H, Some(SEED)).expect("must validate");
+        // and the payout binding genuinely holds
+        assert_eq!(b.solver_pkh, hash160(&b.assignment_public_key));
+    }
+
+    /// Each rejection asserts the SPECIFIC error, not merely that something failed --
+    /// a test that accepts any error passes for the wrong reason.
+    #[test]
+    fn each_malformation_is_rejected_with_its_own_reason() {
+        let ok = RoleBundleV1::from_json(&bundle_json(0x02, ROLE_COMPUTE_CONTRIBUTOR)).unwrap();
+
+        let mut b = ok.clone();
+        b.network_id = NET + 1;
+        assert!(b.validate(NET, H, None).unwrap_err().contains("wrong network"));
+
+        let mut b = ok.clone();
+        b.target_height = H + 1;
+        assert!(b.validate(NET, H, None).unwrap_err().contains("wrong height"));
+
+        let mut b = ok.clone();
+        b.role_id = crate::poawx_proposer::ROLE_PROPOSER;
+        assert!(b
+            .validate(NET, H, None)
+            .unwrap_err()
+            .contains("not a collectable contributor role"));
+
+        // THE PAYOUT BINDING -- the rule that makes a bundle payable at all.
+        let mut b = ok.clone();
+        b.solver_pkh[0] ^= 0xff;
+        assert!(b
+            .validate(NET, H, None)
+            .unwrap_err()
+            .contains("solver pkh not derived from assignment key"));
+
+        let mut b = ok.clone();
+        b.assignment_proof.role_id = ROLE_VERIFY_CONTRIBUTOR;
+        assert!(b
+            .validate(NET, H, None)
+            .unwrap_err()
+            .contains("assignment proof role mismatch"));
+
+        let mut b = ok.clone();
+        assert!(b
+            .validate(NET, H, Some([0x00u8; 32]))
+            .unwrap_err()
+            .contains("wrong seed"));
+        let _ = &mut b;
+
+        // a tampered ECVRF proof must fail the curve check, not slip through
+        let mut b = ok.clone();
+        b.assignment_proof.vrf_output[0] ^= 0xff;
+        assert!(b.validate(NET, H, Some(SEED)).is_err());
+    }
+
+    #[test]
+    fn pool_keeps_best_per_role_and_prunes_on_height_advance() {
+        let pool = NodeRoleBundlePool::default();
+        let a = RoleBundleV1::from_json(&bundle_json(0x03, ROLE_COMPUTE_CONTRIBUTOR)).unwrap();
+        let b = RoleBundleV1::from_json(&bundle_json(0x04, ROLE_COMPUTE_CONTRIBUTOR)).unwrap();
+        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::AcceptedNew);
+        assert_eq!(pool.ingest(b.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::AcceptedNew);
+        // two DISTINCT competitors for the same role are both held; best_for_role picks
+        // the higher self-VRF score, matching on-chain best_for_role ordering.
+        let best = pool.best_for_role(ROLE_COMPUTE_CONTRIBUTOR, H).unwrap();
+        let expect = if a.score() >= b.score() { &a } else { &b };
+        assert_eq!(best.solver_pkh, expect.solver_pkh);
+        assert_eq!(pool.len(), 2);
+        // resubmitting the same worker is a duplicate, not growth
+        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::Duplicate);
+        assert_eq!(pool.len(), 2);
+        // A bundle genuinely targeting an OLDER height is refused as stale. Note the
+        // bundle must really be for H-1: validate() checks target_height first, so
+        // submitting an H-bundle as H-1 fails earlier with "wrong height" instead --
+        // which is what an earlier version of this test asserted, and it would have
+        // passed while never exercising the stale branch at all.
+        let old_b = RoleBundleV1::from_json(&bundle_json_at(0x03, ROLE_COMPUTE_CONTRIBUTOR, H - 1))
+            .unwrap();
+        assert!(pool
+            .ingest(old_b, NET, H - 1, Some(SEED))
+            .unwrap_err()
+            .contains("stale height"));
+        // advancing the height clears everything: bundles are height-bound
+        pool.prune_below(H + 1);
+        assert_eq!(pool.len(), 0);
+        assert!(pool.best_for_role(ROLE_COMPUTE_CONTRIBUTOR, H).is_none());
+    }
+
+    #[test]
+    fn collect_roles_reports_distinct_payees() {
+        let pool = NodeRoleBundlePool::default();
+        for (sk, role) in [
+            (0x05u8, ROLE_COMPUTE_CONTRIBUTOR),
+            (0x06, ROLE_VERIFY_CONTRIBUTOR),
+            (0x07, ROLE_SUPPORT_CONTRIBUTOR),
+        ] {
+            let b = RoleBundleV1::from_json(&bundle_json(sk, role)).unwrap();
+            pool.ingest(b, NET, H, Some(SEED)).unwrap();
+        }
+        let c = CollectedRoles {
+            compute: pool.best_for_role(ROLE_COMPUTE_CONTRIBUTOR, H),
+            verify: pool.best_for_role(ROLE_VERIFY_CONTRIBUTOR, H),
+            support: pool.best_for_role(ROLE_SUPPORT_CONTRIBUTOR, H),
+        };
+        assert_eq!(c.distinct_payees(), 3, "three distinct workers collected");
+        assert!(!c.is_empty());
+    }
+
+    #[test]
+    fn empty_pool_yields_no_collected_roles_so_builders_are_unchanged() {
+        let c = collect_roles_for_height(u64::MAX); // nothing ever ingested at this height
+        assert!(c.is_empty());
+        assert_eq!(c.distinct_payees(), 0);
+    }
+}

--- a/src/poawx_role_bundle.rs
+++ b/src/poawx_role_bundle.rs
@@ -33,6 +33,7 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::poawx_candidate::AssignmentProofV2;
 use crate::poawx_puzzle::PuzzleSolutionV1;
+use crate::poawx_finality::FinalityVoteV1;
 use crate::poawx_ticket::TicketProof;
 
 /// Hard bound on pooled bundles. Small: bundles are height-scoped and pruned, and only
@@ -70,6 +71,14 @@ pub struct RoleBundleV1 {
     pub claim_nonce: [u8; 32],
     pub commitment_hash: [u8; 32],
     pub claim_digest: [u8; 32],
+    /// R4: SUPPORT doubles as the FINALITY COMMITTEE MEMBER, so a collected SUPPORT
+    /// worker must supply its own signed finality vote -- the builder holds no key for
+    /// it. `None` for COMPUTE/VERIFY, which have no committee role.
+    ///
+    /// The vote binds to the PARENT block (block_hash = prev_hash), not to the block
+    /// under construction, so a worker can produce it at bundle-build time without
+    /// circularity.
+    pub finality_vote: Option<FinalityVoteV1>,
 }
 
 fn hex_field(v: &serde_json::Value, k: &str) -> Result<Vec<u8>, String> {
@@ -128,6 +137,13 @@ impl RoleBundleV1 {
                 "claim.commitment_hash",
             )?,
             claim_digest: fixed::<32>(hex_field(claim, "claim_digest")?, "claim.claim_digest")?,
+            finality_vote: match v.get("finality_vote").and_then(|x| x.as_str()) {
+                Some(h) => Some(FinalityVoteV1::deserialize(
+                    &hex::decode(h)
+                        .map_err(|e| format!("role bundle: finality_vote not hex: {e}"))?,
+                )?),
+                None => None,
+            },
         })
     }
 
@@ -146,6 +162,7 @@ impl RoleBundleV1 {
         expected_network: u8,
         expected_height: u64,
         expected_seed: Option<[u8; 32]>,
+        expected_parent: Option<[u8; 32]>,
     ) -> Result<(), String> {
         if self.network_id != expected_network {
             return Err("role bundle: wrong network".to_string());
@@ -181,6 +198,61 @@ impl RoleBundleV1 {
         self.assignment_proof
             .validate(expected_network, expected_height)
             .map_err(|e| format!("role bundle: {e}"))?;
+        self.validate_finality_vote(expected_network, expected_height, expected_parent)?;
+        Ok(())
+    }
+
+    /// R4: a SUPPORT bundle MUST carry a valid, self-signed finality vote; any other
+    /// role must not carry one. Every field is recomputed or re-derived, never trusted.
+    fn validate_finality_vote(
+        &self,
+        expected_network: u8,
+        expected_height: u64,
+        expected_parent: Option<[u8; 32]>,
+    ) -> Result<(), String> {
+        let is_support = self.role_id == crate::poawx::ROLE_SUPPORT_CONTRIBUTOR;
+        let v = match (&self.finality_vote, is_support) {
+            (Some(_), false) => {
+                return Err("role bundle: finality vote on a non-SUPPORT role".to_string())
+            }
+            (None, true) => {
+                return Err("role bundle: SUPPORT bundle missing its finality vote".to_string())
+            }
+            (None, false) => return Ok(()),
+            (Some(v), true) => v,
+        };
+        if v.network_id != expected_network {
+            return Err("role bundle: finality vote wrong network".to_string());
+        }
+        if v.target_height != expected_height {
+            return Err("role bundle: finality vote wrong height".to_string());
+        }
+        if v.vote_type != crate::poawx_finality::FinalityVoteType::Commit.id() {
+            return Err("role bundle: finality vote is not a Commit".to_string());
+        }
+        // The member identity must be the worker's own, derived not declared.
+        if v.member_pkh != hash160(&v.member_pubkey) {
+            return Err("role bundle: finality vote member pkh not derived from its pubkey"
+                .to_string());
+        }
+        if v.member_pkh != self.solver_pkh {
+            return Err("role bundle: finality vote member pkh != solver pkh".to_string());
+        }
+        // The vote finalizes the PARENT, so it must name the parent we expect.
+        if let Some(parent) = expected_parent {
+            if v.block_hash != parent {
+                return Err("role bundle: finality vote wrong parent block hash".to_string());
+            }
+        }
+        // Bind the vote to the worker's OWN ticket. The chain does NOT enforce this --
+        // FinalityProofV1::validate never cross-checks ticket_digest against anything
+        // external, so the field is signed but otherwise free. Binding it here keeps a
+        // collected bundle internally coherent rather than merely self-consistent.
+        if v.ticket_digest != self.ticket_proof.ticket_digest {
+            return Err("role bundle: finality vote ticket digest != bundle ticket".to_string());
+        }
+        v.verify(expected_network, expected_height, &v.block_hash)
+            .map_err(|e| format!("role bundle: finality vote {e}"))?;
         Ok(())
     }
 }
@@ -217,8 +289,9 @@ impl NodeRoleBundlePool {
         expected_network: u8,
         expected_height: u64,
         expected_seed: Option<[u8; 32]>,
+        expected_parent: Option<[u8; 32]>,
     ) -> Result<BundleOutcome, String> {
-        bundle.validate(expected_network, expected_height, expected_seed)?;
+        bundle.validate(expected_network, expected_height, expected_seed, expected_parent)?;
         let mut g = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         if expected_height > g.height {
             g.height = expected_height;
@@ -254,6 +327,7 @@ impl NodeRoleBundlePool {
         expected_network: u8,
         expected_height: u64,
         expected_seed: Option<[u8; 32]>,
+        expected_parent: Option<[u8; 32]>,
     ) -> Result<BundleOutcome, String> {
         // TIER 1 -- per source. Cheap, and it runs BEFORE validation so that the cost of
         // validating is itself protected.
@@ -262,13 +336,13 @@ impl NodeRoleBundlePool {
         }
         // TIER 2 -- validation. Counted so a test can prove tier 1 short-circuits it.
         VALIDATIONS_PERFORMED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        bundle.validate(expected_network, expected_height, expected_seed)?;
+        bundle.validate(expected_network, expected_height, expected_seed, expected_parent)?;
         // TIER 3 -- per identity, only ever reached by an identity that already cost a
         // real ECVRF prove.
         if !identity_rate_allowed(&bundle.solver_pkh) {
             return Err("role bundle: identity rate limited".to_string());
         }
-        self.ingest(bundle, expected_network, expected_height, expected_seed)
+        self.ingest(bundle, expected_network, expected_height, expected_seed, expected_parent)
     }
 
     pub fn ingest_json(
@@ -277,9 +351,10 @@ impl NodeRoleBundlePool {
         expected_network: u8,
         expected_height: u64,
         expected_seed: Option<[u8; 32]>,
+        expected_parent: Option<[u8; 32]>,
     ) -> Result<BundleOutcome, String> {
         let b = RoleBundleV1::from_json(json)?;
-        self.ingest(b, expected_network, expected_height, expected_seed)
+        self.ingest(b, expected_network, expected_height, expected_seed, expected_parent)
     }
 
     /// Highest-scoring collected bundle for `role_id` at the pool's current height.
@@ -447,6 +522,7 @@ mod tests {
     const NET: u8 = 2; // devnet
     const H: u64 = 42;
     const SEED: [u8; 32] = [0x5Au8; 32];
+    const PARENT: [u8; 32] = [0x11u8; 32];
 
     /// Build a genuinely valid bundle for `secret` in `role`, in the exact JSON shape
     /// `poawx-role-worker` emits, so the fixture exercises the real parser.
@@ -461,9 +537,28 @@ mod tests {
         let pkh = proof.solver_pkh;
         let apk = proof.assignment_public_key;
         let ticket = TicketProof::new(
-            NET, height, [0x11u8; 32], role, pkh, height, height + 100, apk, [0x22u8; 32], 0,
+            NET, height, PARENT, role, pkh, height, height + 100, apk, [0x22u8; 32], 0,
         );
         let sol = PuzzleSolutionV1 { mode: 0, nonce: 7, proof_digest: [0x33u8; 32] };
+        // R4: a SUPPORT bundle must carry the worker's own signed finality vote.
+        let fv = if role == crate::poawx::ROLE_SUPPORT_CONTRIBUTOR {
+            let sk = k256::ecdsa::SigningKey::from_bytes((&secret).into()).unwrap();
+            Some(hex::encode(
+                crate::poawx_finality::FinalityVoteV1::signed(
+                    &sk,
+                    NET,
+                    height,
+                    PARENT,
+                    [0u8; 32],
+                    0,
+                    ticket.ticket_digest,
+                    crate::poawx_finality::FinalityVoteType::Commit,
+                )
+                .serialize(),
+            ))
+        } else {
+            None
+        };
         serde_json::json!({
             "network_id": NET, "target_height": height, "role_id": role, "role": "compute",
             "solver_pkh": hex::encode(pkh),
@@ -478,6 +573,7 @@ mod tests {
                 "commitment_hash": hex::encode([0x66u8; 32]),
                 "claim_digest": hex::encode([0x77u8; 32]),
             },
+            "finality_vote": fv,
         })
         .to_string()
     }
@@ -485,7 +581,7 @@ mod tests {
     #[test]
     fn valid_bundle_parses_and_validates() {
         let b = RoleBundleV1::from_json(&bundle_json(0x01, ROLE_COMPUTE_CONTRIBUTOR)).expect("parse");
-        b.validate(NET, H, Some(SEED)).expect("must validate");
+        b.validate(NET, H, Some(SEED), None).expect("must validate");
         // and the payout binding genuinely holds
         assert_eq!(b.solver_pkh, hash160(&b.assignment_public_key));
     }
@@ -498,16 +594,16 @@ mod tests {
 
         let mut b = ok.clone();
         b.network_id = NET + 1;
-        assert!(b.validate(NET, H, None).unwrap_err().contains("wrong network"));
+        assert!(b.validate(NET, H, None, None).unwrap_err().contains("wrong network"));
 
         let mut b = ok.clone();
         b.target_height = H + 1;
-        assert!(b.validate(NET, H, None).unwrap_err().contains("wrong height"));
+        assert!(b.validate(NET, H, None, None).unwrap_err().contains("wrong height"));
 
         let mut b = ok.clone();
         b.role_id = crate::poawx_proposer::ROLE_PROPOSER;
         assert!(b
-            .validate(NET, H, None)
+            .validate(NET, H, None, None)
             .unwrap_err()
             .contains("not a collectable contributor role"));
 
@@ -515,20 +611,20 @@ mod tests {
         let mut b = ok.clone();
         b.solver_pkh[0] ^= 0xff;
         assert!(b
-            .validate(NET, H, None)
+            .validate(NET, H, None, None)
             .unwrap_err()
             .contains("solver pkh not derived from assignment key"));
 
         let mut b = ok.clone();
         b.assignment_proof.role_id = ROLE_VERIFY_CONTRIBUTOR;
         assert!(b
-            .validate(NET, H, None)
+            .validate(NET, H, None, None)
             .unwrap_err()
             .contains("assignment proof role mismatch"));
 
         let mut b = ok.clone();
         assert!(b
-            .validate(NET, H, Some([0x00u8; 32]))
+            .validate(NET, H, Some([0x00u8; 32]), None)
             .unwrap_err()
             .contains("wrong seed"));
         let _ = &mut b;
@@ -536,7 +632,7 @@ mod tests {
         // a tampered ECVRF proof must fail the curve check, not slip through
         let mut b = ok.clone();
         b.assignment_proof.vrf_output[0] ^= 0xff;
-        assert!(b.validate(NET, H, Some(SEED)).is_err());
+        assert!(b.validate(NET, H, Some(SEED), None).is_err());
     }
 
     #[test]
@@ -544,8 +640,8 @@ mod tests {
         let pool = NodeRoleBundlePool::default();
         let a = RoleBundleV1::from_json(&bundle_json(0x03, ROLE_COMPUTE_CONTRIBUTOR)).unwrap();
         let b = RoleBundleV1::from_json(&bundle_json(0x04, ROLE_COMPUTE_CONTRIBUTOR)).unwrap();
-        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::AcceptedNew);
-        assert_eq!(pool.ingest(b.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::AcceptedNew);
+        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED), None).unwrap(), BundleOutcome::AcceptedNew);
+        assert_eq!(pool.ingest(b.clone(), NET, H, Some(SEED), None).unwrap(), BundleOutcome::AcceptedNew);
         // two DISTINCT competitors for the same role are both held; best_for_role picks
         // the higher self-VRF score, matching on-chain best_for_role ordering.
         let best = pool.best_for_role(ROLE_COMPUTE_CONTRIBUTOR, H).unwrap();
@@ -553,7 +649,7 @@ mod tests {
         assert_eq!(best.solver_pkh, expect.solver_pkh);
         assert_eq!(pool.len(), 2);
         // resubmitting the same worker is a duplicate, not growth
-        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED)).unwrap(), BundleOutcome::Duplicate);
+        assert_eq!(pool.ingest(a.clone(), NET, H, Some(SEED), None).unwrap(), BundleOutcome::Duplicate);
         assert_eq!(pool.len(), 2);
         // A bundle genuinely targeting an OLDER height is refused as stale. Note the
         // bundle must really be for H-1: validate() checks target_height first, so
@@ -563,7 +659,7 @@ mod tests {
         let old_b = RoleBundleV1::from_json(&bundle_json_at(0x03, ROLE_COMPUTE_CONTRIBUTOR, H - 1))
             .unwrap();
         assert!(pool
-            .ingest(old_b, NET, H - 1, Some(SEED))
+            .ingest(old_b, NET, H - 1, Some(SEED), None)
             .unwrap_err()
             .contains("stale height"));
         // advancing the height clears everything: bundles are height-bound
@@ -581,7 +677,7 @@ mod tests {
             (0x07, ROLE_SUPPORT_CONTRIBUTOR),
         ] {
             let b = RoleBundleV1::from_json(&bundle_json(sk, role)).unwrap();
-            pool.ingest(b, NET, H, Some(SEED)).unwrap();
+            pool.ingest(b, NET, H, Some(SEED), None).unwrap();
         }
         let c = CollectedRoles {
             compute: pool.best_for_role(ROLE_COMPUTE_CONTRIBUTOR, H),
@@ -635,7 +731,7 @@ mod r1_r2_r3_tests {
         let mut exhausted = false;
         for _ in 0..10_000 {
             if pool
-                .ingest_tiered(src, b.clone(), NET, H, Some(SEED))
+                .ingest_tiered(src, b.clone(), NET, H, Some(SEED), None)
                 .err()
                 .map(|e| e.contains("source rate limited"))
                 .unwrap_or(false)
@@ -648,7 +744,7 @@ mod r1_r2_r3_tests {
         // With tier 1 now rejecting, validation must NOT run.
         let before = VALIDATIONS_PERFORMED.load(Ordering::Relaxed);
         let err = pool
-            .ingest_tiered(src, b, NET, H, Some(SEED))
+            .ingest_tiered(src, b, NET, H, Some(SEED), None)
             .expect_err("must still be source-limited");
         assert!(err.contains("source rate limited"), "got: {err}");
         assert_eq!(
@@ -668,7 +764,7 @@ mod r1_r2_r3_tests {
         let mut identity_limited = false;
         // A different source every time, so tier 1 is always fresh.
         for i in 0..(IDENTITY_RATE_MAX + 4) {
-            let r = pool.ingest_tiered(ip(100 + i as u8), b.clone(), NET, H, Some(SEED));
+            let r = pool.ingest_tiered(ip(100 + i as u8), b.clone(), NET, H, Some(SEED), None);
             if let Err(e) = r {
                 if e.contains("identity rate limited") {
                     identity_limited = true;
@@ -690,10 +786,10 @@ mod r1_r2_r3_tests {
         let pool = NodeRoleBundlePool::default();
         let noisy = valid_bundle(0x23);
         for i in 0..(IDENTITY_RATE_MAX + 4) {
-            let _ = pool.ingest_tiered(ip(150 + i as u8), noisy.clone(), NET, H, Some(SEED));
+            let _ = pool.ingest_tiered(ip(150 + i as u8), noisy.clone(), NET, H, Some(SEED), None);
         }
         let quiet = valid_bundle(0x24);
-        let r = pool.ingest_tiered(ip(200), quiet, NET, H, Some(SEED));
+        let r = pool.ingest_tiered(ip(200), quiet, NET, H, Some(SEED), None);
         assert!(
             !matches!(&r, Err(e) if e.contains("identity rate limited")),
             "a quiet worker was limited because a different one flooded: {r:?}"
@@ -713,5 +809,123 @@ mod r1_r2_r3_tests {
         std::env::set_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC", "0");
         assert!(!role_bundle_public_submission_enabled(), "only \"1\" enables it");
         std::env::remove_var("IRIUM_POAWX_ROLE_BUNDLE_PUBLIC");
+    }
+}
+
+#[cfg(test)]
+mod r4_finality_vote_tests {
+    use super::*;
+    use crate::poawx::{ROLE_COMPUTE_CONTRIBUTOR, ROLE_SUPPORT_CONTRIBUTOR};
+    use crate::poawx_finality::{FinalityVoteType, FinalityVoteV1};
+
+    const NET: u8 = 2;
+    const H: u64 = 42;
+    const SEED: [u8; 32] = [0x5Au8; 32];
+    const PARENT: [u8; 32] = [0x11u8; 32];
+
+    fn support_bundle(b: u8) -> RoleBundleV1 {
+        RoleBundleV1::from_json(&super::tests::bundle_json(b, ROLE_SUPPORT_CONTRIBUTOR))
+            .expect("parse")
+    }
+
+    #[test]
+    fn valid_support_bundle_with_its_own_vote_validates() {
+        let b = support_bundle(0x31);
+        b.validate(NET, H, Some(SEED), Some(PARENT))
+            .expect("SUPPORT bundle with its own vote must validate");
+        let v = b.finality_vote.as_ref().expect("vote present");
+        assert_eq!(v.member_pkh, b.solver_pkh, "the voter IS the paid worker");
+    }
+
+    /// Each malformation asserts its SPECIFIC error. A test that accepts any error
+    /// passes for the wrong reason.
+    #[test]
+    fn each_vote_malformation_is_rejected_with_its_own_reason() {
+        let ok = support_bundle(0x32);
+
+        // SUPPORT without a vote at all
+        let mut b = ok.clone();
+        b.finality_vote = None;
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("SUPPORT bundle missing its finality vote"));
+
+        // a non-SUPPORT role carrying one
+        let mut b = RoleBundleV1::from_json(&super::tests::bundle_json(
+            0x33,
+            ROLE_COMPUTE_CONTRIBUTOR,
+        ))
+        .unwrap();
+        b.finality_vote = ok.finality_vote.clone();
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("finality vote on a non-SUPPORT role"));
+
+        // bad signature
+        let mut b = ok.clone();
+        b.finality_vote.as_mut().unwrap().signature[0] ^= 0xff;
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("finality vote"));
+
+        // member_pkh not derived from member_pubkey
+        let mut b = ok.clone();
+        b.finality_vote.as_mut().unwrap().member_pkh[0] ^= 0xff;
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("member pkh not derived from its pubkey"));
+
+        // member_pkh valid but belonging to a DIFFERENT worker than the payee
+        let other = support_bundle(0x34);
+        let mut b = ok.clone();
+        b.finality_vote = other.finality_vote.clone();
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("member pkh != solver pkh"));
+
+        // wrong height
+        let mut b = ok.clone();
+        b.finality_vote.as_mut().unwrap().target_height = H + 1;
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("finality vote wrong height"));
+
+        // wrong parent block hash
+        let mut b = ok.clone();
+        b.finality_vote.as_mut().unwrap().block_hash = [0x99u8; 32];
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("wrong parent block hash"));
+
+        // wrong vote type
+        let mut b = ok.clone();
+        b.finality_vote.as_mut().unwrap().vote_type =
+            FinalityVoteType::Commit.id().wrapping_add(1);
+        assert!(b
+            .validate(NET, H, Some(SEED), Some(PARENT))
+            .unwrap_err()
+            .contains("not a Commit"));
+
+        // THE FLAGGED BUG SITE: ticket_digest unbound from the worker's real ticket.
+        // The chain does NOT enforce this -- FinalityProofV1::validate never cross-checks
+        // it -- so a vote with a foreign ticket digest still verifies cryptographically.
+        // Ingest binds it so a collected bundle is coherent, not merely self-consistent.
+        let mut b = ok.clone();
+        let sk = k256::ecdsa::SigningKey::from_bytes(&[0x32u8; 32].into()).unwrap();
+        b.finality_vote = Some(FinalityVoteV1::signed(
+            &sk, NET, H, PARENT, [0u8; 32], 0, [0xEEu8; 32], FinalityVoteType::Commit,
+        ));
+        let e = b.validate(NET, H, Some(SEED), Some(PARENT)).unwrap_err();
+        assert!(
+            e.contains("ticket digest != bundle ticket"),
+            "a validly-signed vote over a FOREIGN ticket digest must still be rejected; got: {e}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Merges the PoAW-X **role-bundle collection channel (R1–R4)** plus the **height-2 dominance-weight fix** onto current `main`. This is the capability that lets independent COMPUTE/VERIFY/SUPPORT workers each submit a real role bundle and have a proposer assemble a block that pays four distinct parties the 55/22/13/10 split — proven end-to-end and continuously on an isolated devnet.

**This is Stage 1 of the production plan: merge-ready, source only. It changes nothing on mainnet and does not deploy anything.** Deploy (Stage 2) and every later stage are separate, explicitly-gated decisions.

## What's in it

- **R1–R3** — `poawx_role_bundle.rs`: `RoleBundleV1` wire type + `to_json` round-trip, `NodeRoleBundlePool` with tiered/per-identity rate limiting, and the endpoints `POST /poawx/role-bundle`, `GET /poawx/role-work`, `GET /poawx/collected-bundles`.
- **R4** — SUPPORT doubles as the finality-committee member and self-signs its own `FinalityVoteV1` (the builder holds no key for it).
- **Multi-party assembly** — `build_collected_poawx_block_with_parent` builds a block from collected public artifacts + the proposer's own key; the dev-only `poawx-collected-proposer` binary drives it.
- **Height-2 fix** — the worker now derives its candidate `dominance_weight` from the node-authoritative dominance snapshot the endpoint ships (`PersistentDominance::weight`) instead of hardcoding `1000`. That hardcode only matched the node weight when dominance was empty (height 1); at height ≥2 it diverged and assembly looped on `proof digest mismatch`. Worker-side only; no consensus change.

## Safety posture — inert and opt-in by construction

- **Endpoints are loopback-only** (`role_bundle_bridge_guard`); non-loopback is refused unless `role_bundle_public_submission_enabled()` (R2) is set — **default off** (test `public_submission_defaults_off_and_is_opt_in`).
- `GET /poawx/collected-bundles` is additionally **mainnet-hard-off** (`network_id==0 → FORBIDDEN`).
- `poawx-collected-proposer` **refuses mainnet** (`network_id==0`).
- **Nothing in the live block path consumes the pool.** `getblocktemplate` / `/poawx/receipt` / stratum read none of it — the pool keeps producing solo blocks. (Test `empty_pool_yields_no_collected_roles_so_builders_are_unchanged`.)
- **No activation const changes. No stratum changes. Solo mining is the unaffected default.**
- **P3-a (making distinct payees mandatory) is explicitly NOT in scope** — this makes multi-party *possible* when a proposer opts in; it adds no requirement and no consensus tightening.

## Testing

- Full lib suite: **915 passed, 0 failed** (serial).
- Full bin suite: green (exit 0).
- Dominance fix: `worker_and_builder_agree_on_puzzle_challenge_at_height_two`, `hardcoded_weight_breaks_puzzle_verification_at_height_two` (prove-the-break), `seed_non_divergence_endpoint_matches_builder_at_height_two`.
- R1–R4: pool/rate-limit/finality-vote unit tests; the mainnet-faithful `#[ignore]`d rig tests `phase4_real_worker_bundles_land_block_distinct_recipients` and `..._with_proposer_vrf_enforced` pass.
- Isolated devnet: continuous production across heights 2–30, four distinct payees every block, zero node rejections (recorded in ops-records).

## Rebase note

Rebased cleanly onto `main` (955c33a) with zero conflicts across the six commits. Conflict-surface files (`iriumd.rs`, `chain.rs`, `lib.rs`, `Cargo.lock`) merged without manual resolution.
