### PR TITLE
docs: migrate pool/website URLs iriumlabs.org -> irium.org

### DIFF
--- a/GPU-MINER.md
+++ b/GPU-MINER.md
@@ -15,7 +15,7 @@ cargo build --release --features gpu --bin irium-miner-gpu
 
 ```bash
 ./target/release/irium-miner-gpu \
-  --pool   stratum+tcp://pool.iriumlabs.org:3333 \
+  --pool   stratum+tcp://pool.irium.org:3333 \
   --wallet <your_address>
 ```
 
@@ -69,7 +69,7 @@ The combined hashrate is displayed every 10 seconds.
 All flags can also be set via environment variables or a `.env` / `miner.env` / `irium.env` file:
 
 ```
-IRIUM_STRATUM_URL=stratum+tcp://pool.iriumlabs.org:3333
+IRIUM_STRATUM_URL=stratum+tcp://pool.irium.org:3333
 IRIUM_MINER_ADDRESS=PxkXHsFZo2sbAfo2EeKdpdrFsZigDzbxqu
 IRIUM_NODE_RPC=http://192.168.1.58:38300
 IRIUM_GPU_DEVICES=0,1,2,3    # comma-separated; overrides IRIUM_GPU_DEVICE

--- a/MINING-QUICKSTART.txt
+++ b/MINING-QUICKSTART.txt
@@ -15,7 +15,7 @@ with P or Q). It is saved to mine-config.txt next to the script so
 you only enter it once. Mining auto-restarts if it crashes.
 
 GPU scripts connect to the official Irium pool at
-stratum+tcp://pool.iriumlabs.org:3335 in SOLO payout mode -- when one
+stratum+tcp://pool.irium.org:3335 in SOLO payout mode -- when one
 of your shares meets the network target, the FULL block reward
 (currently 50 IRM) lands at your wallet address. No pool fee.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -191,7 +191,7 @@ starts syncing, check its status:
 curl http://127.0.0.1:38300/status
 ```
 
-You will see the current block height and peer count. The node is synced when `height` matches the network tip. Network status is also visible at [iriumlabs.org](https://www.iriumlabs.org).
+You will see the current block height and peer count. The node is synced when `height` matches the network tip. Network status is also visible at [irium.org](https://www.irium.org).
 
 Check your balance:
 
@@ -247,20 +247,20 @@ Pool mining splits the reward across many miners so you get small payments regul
 
 | Hardware | Pool endpoint |
 |----------|--------------|
-| CPU or GPU | `stratum+tcp://pool.iriumlabs.org:3335` |
-| ASIC | `stratum+tcp://pool.iriumlabs.org:3333` |
-| Behind ISP that blocks 3333/3335 (notably China) | `stratum+tcp://pool.iriumlabs.org:443` — same Stratum protocol on the HTTPS port to bypass filtering |
-| Solo (full 50 IRM coinbase to block finder, 0% pool fee) | `stratum+tcp://pool.iriumlabs.org:3336` |
+| CPU or GPU | `stratum+tcp://pool.irium.org:3335` |
+| ASIC | `stratum+tcp://pool.irium.org:3333` |
+| Behind ISP that blocks 3333/3335 (notably China) | `stratum+tcp://pool.irium.org:443` — same Stratum protocol on the HTTPS port to bypass filtering |
+| Solo (full 50 IRM coinbase to block finder, 0% pool fee) | `stratum+tcp://pool.irium.org:3336` |
 
 For the bundled GPU miner:
 
 ```bash
 irium-miner-gpu \
-  --pool stratum+tcp://pool.iriumlabs.org:3335 \
+  --pool stratum+tcp://pool.irium.org:3335 \
   --wallet <YOUR_ADDRESS>
 ```
 
-Your `<YOUR_ADDRESS>` is also your worker name — the pool credits payouts directly to it. Live pool stats (active miners, blocks found, rolling-window hashrate per profile) are available at `http://pool.iriumlabs.org:3337/stats` and are surfaced in the desktop app's Explorer tab.
+Your `<YOUR_ADDRESS>` is also your worker name — the pool credits payouts directly to it. Live pool stats (active miners, blocks found, rolling-window hashrate per profile) are available at `http://pool.irium.org:3337/stats` and are surfaced in the desktop app's Explorer tab.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Release](https://img.shields.io/github/v/release/iriumlabs/irium?label=release&color=green)](https://github.com/iriumlabs/irium/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-lightgrey)](LICENSE)
-[![Mainnet](https://img.shields.io/badge/Mainnet-Live-brightgreen)](https://www.iriumlabs.org)
+[![Mainnet](https://img.shields.io/badge/Mainnet-Live-brightgreen)](https://www.irium.org)
 
 ---
 
@@ -76,11 +76,11 @@ SHA-256d consensus. No premine. No admin keys. 100,000,000 IRM total supply (96.
 | Default P2P port | 38291 |
 | Default RPC / explorer port | 38300 |
 | `/status` lightweight port | 8080 (loopback only by default) |
-| Official pool — CPU/GPU | `stratum+tcp://pool.iriumlabs.org:3335` |
-| Official pool — ASIC | `stratum+tcp://pool.iriumlabs.org:3333` |
-| Official pool — firewall bypass | `stratum+tcp://pool.iriumlabs.org:443` (sslh-multiplexed; for environments blocking high ports) |
-| Official pool — solo | `stratum+tcp://pool.iriumlabs.org:3336` (full 50 IRM coinbase payout directly to the block finder; 0% pool fee) |
-| Public pool stats proxy | `http://pool.iriumlabs.org:3337/stats` |
+| Official pool — CPU/GPU | `stratum+tcp://pool.irium.org:3335` |
+| Official pool — ASIC | `stratum+tcp://pool.irium.org:3333` |
+| Official pool — firewall bypass | `stratum+tcp://pool.irium.org:443` (sslh-multiplexed; for environments blocking high ports) |
+| Official pool — solo | `stratum+tcp://pool.irium.org:3336` (full 50 IRM coinbase payout directly to the block finder; 0% pool fee) |
+| Public pool stats proxy | `http://pool.irium.org:3337/stats` |
 
 ---
 
@@ -185,12 +185,12 @@ The node connects to the Irium network automatically. On first run it uses the s
 |---------|----------------|
 | Solo CPU | `irium-miner --address Q<your-address>` |
 | Solo GPU | `irium-miner-gpu --address Q<your-address>` (build with `--features gpu`) |
-| Pool — CPU/GPU | Point any Stratum v1 miner at `stratum+tcp://pool.iriumlabs.org:3335`, worker `Q<your-address>` |
-| Pool — ASIC | Point any SHA-256 ASIC at `stratum+tcp://pool.iriumlabs.org:3333`, worker `Q<your-address>` |
-| Pool — fallback (port 3333 blocked) | `stratum+tcp://pool.iriumlabs.org:443` — same Stratum protocol on HTTPS port to bypass ISP filtering (notably in China) |
+| Pool — CPU/GPU | Point any Stratum v1 miner at `stratum+tcp://pool.irium.org:3335`, worker `Q<your-address>` |
+| Pool — ASIC | Point any SHA-256 ASIC at `stratum+tcp://pool.irium.org:3333`, worker `Q<your-address>` |
+| Pool — fallback (port 3333 blocked) | `stratum+tcp://pool.irium.org:443` — same Stratum protocol on HTTPS port to bypass ISP filtering (notably in China) |
 
-Public pool stats live at [https://pool.iriumlabs.org/stats](https://pool.iriumlabs.org/stats) and at the raw proxy
-`http://pool.iriumlabs.org:3337/stats` (CORS-enabled JSON with active miners, accepted shares, blocks found, current
+Public pool stats live at [https://pool.irium.org/stats](https://pool.irium.org/stats) and at the raw proxy
+`http://pool.irium.org:3337/stats` (CORS-enabled JSON with active miners, accepted shares, blocks found, current
 share difficulty, and a rolling-window hashrate estimate per profile).
 
 After block 23,500 activates Fix 2a, every SHA-256d miner (ASIC, GPU, CPU)

--- a/docs/LISTING-APPLICATION.md
+++ b/docs/LISTING-APPLICATION.md
@@ -60,7 +60,7 @@ This document is ready to copy and send to exchange listing teams, pool aggregat
 - Marketplace: on-chain OTC offer feed and agreement execution
 - Reputation system: on-chain outcome tracking per seller pubkey
 - REST API on every node: balance queries, block/tx lookup, mempool, offer feed
-- Public Stratum pool: `pool.iriumlabs.org:3333` (ASIC), `:3335` (CPU/GPU)
+- Public Stratum pool: `pool.irium.org:3333` (ASIC), `:3335` (CPU/GPU)
 - Docker images: `ghcr.io/iriumlabs/irium:latest`
 - Pre-built release binaries: Linux x86_64/ARM64, macOS Intel/ARM, Windows
 
@@ -80,11 +80,11 @@ The full AuxPoW implementation is in the current codebase. See `docs/MERGED-MINI
 
 | Resource | URL |
 |----------|-----|
-| Website | https://www.iriumlabs.org |
+| Website | https://www.irium.org |
 | GitHub | https://github.com/iriumlabs/irium |
 | Whitepaper | https://github.com/iriumlabs/irium/blob/main/docs/WHITEPAPER.md |
-| Block explorer | https://www.iriumlabs.org/explorer |
-| Public pool | https://www.iriumlabs.org/pool |
+| Block explorer | https://www.irium.org/explorer |
+| Public pool | https://www.irium.org/pool |
 | Telegram | https://t.me/iriumlabs |
 | RPC API reference | https://github.com/iriumlabs/irium/blob/main/docs/API.md |
 | Wallet CLI reference | https://github.com/iriumlabs/irium/blob/main/docs/WALLET-CLI.md |

--- a/docs/MINING.md
+++ b/docs/MINING.md
@@ -46,7 +46,7 @@ on the bundled miner. The macOS scripts additionally remove the
 block the unsigned binary on first launch.
 
 **GPU scripts** connect to the official Irium pool at
-`stratum+tcp://pool.iriumlabs.org:3335`. Direct-payout mode: when one
+`stratum+tcp://pool.irium.org:3335`. Direct-payout mode: when one
 of your shares meets the network target, the full 50 IRM block reward
 goes directly to the address you used as your worker name. Zero fees.
 
@@ -104,7 +104,7 @@ Upgrade before block 50,000 — older miners/nodes will reject post-activation b
 
 ## Pool endpoints (official pool)
 
-`pool.iriumlabs.org` is the DNS hostname for the official Irium pool.
+`pool.irium.org` is the DNS hostname for the official Irium pool.
 
 **Unified direct-payout model:** every port runs the same payout
 behaviour. When one of your shares meets the network target, the
@@ -127,11 +127,11 @@ coinbase has no valid output for you**.
 
 **Password:** literally `x` (the conventional Stratum no-op password).
 
-**Live stats:** [https://pool.iriumlabs.org/stats](https://pool.iriumlabs.org/stats)
+**Live stats:** [https://pool.irium.org/stats](https://pool.irium.org/stats)
 shows active miners, accepted/rejected shares, blocks found, and a
 rolling 15-minute hashrate estimate. The raw CORS-enabled JSON proxy
-is at `http://pool.iriumlabs.org:3337/stats` and per-miner detail at
-`http://pool.iriumlabs.org:3337/miners`.
+is at `http://pool.irium.org:3337/stats` and per-miner detail at
+`http://pool.irium.org:3337/miners`.
 
 **Hashrate estimation:** the stats-proxy computes a per-miner hashrate
 over the rolling 15-minute share window using each worker's live
@@ -151,7 +151,7 @@ Bitaxe (Antminer S19-compatible firmware) web UI:
 
 | Field | Value |
 |-------|-------|
-| Stratum URL | `pool.iriumlabs.org` |
+| Stratum URL | `pool.irium.org` |
 | Stratum Port | `3333` (try `443` if your ISP blocks 3333) |
 | Stratum User | `<YOUR_IRM_ADDRESS>.bitaxe1` |
 | Stratum Password | `x` |
@@ -165,7 +165,7 @@ For S19/S21 firmware, the equivalent commit fields are:
 
 | BraiinsOS / Vnish / Stock firmware | Value |
 |---|---|
-| Pool URL | `stratum+tcp://pool.iriumlabs.org:3333` |
+| Pool URL | `stratum+tcp://pool.irium.org:3333` |
 | Worker | `<YOUR_IRM_ADDRESS>.rig1` |
 | Password | `x` |
 
@@ -173,7 +173,7 @@ For S19/S21 firmware, the equivalent commit fields are:
 
 ```
 t-rex -a sha256d \
-      -o stratum+tcp://pool.iriumlabs.org:3335 \
+      -o stratum+tcp://pool.irium.org:3335 \
       -u <YOUR_IRM_ADDRESS>.gpu1 \
       -p x
 ```
@@ -182,7 +182,7 @@ t-rex -a sha256d \
 
 ```
 lolMiner --algo SHA256D \
-         --pool stratum+tcp://pool.iriumlabs.org:3335 \
+         --pool stratum+tcp://pool.irium.org:3335 \
          --user <YOUR_IRM_ADDRESS>.gpu1 \
          --pass x
 ```
@@ -191,7 +191,7 @@ lolMiner --algo SHA256D \
 
 ```
 nbminer -a sha256d \
-        -o stratum+tcp://pool.iriumlabs.org:3335 \
+        -o stratum+tcp://pool.irium.org:3335 \
         -u <YOUR_IRM_ADDRESS>.gpu1 \
         -p x
 ```
@@ -200,7 +200,7 @@ nbminer -a sha256d \
 
 ```
 cpuminer-opt -a sha256d \
-             -o stratum+tcp://pool.iriumlabs.org:3335 \
+             -o stratum+tcp://pool.irium.org:3335 \
              -u <YOUR_IRM_ADDRESS>.cpu1 \
              -p x \
              -t <NUM_THREADS>
@@ -210,7 +210,7 @@ cpuminer-opt -a sha256d \
 
 ```
 irium-miner-gpu \
-  --pool stratum+tcp://pool.iriumlabs.org:3335 \
+  --pool stratum+tcp://pool.irium.org:3335 \
   --wallet <YOUR_IRM_ADDRESS>
 ```
 
@@ -232,7 +232,7 @@ that deep-packet-inspection systems pass it through.
 For any miner, simply swap the port:
 
 ```
-stratum+tcp://pool.iriumlabs.org:443     # works even when 3333/3335 fail
+stratum+tcp://pool.irium.org:443     # works even when 3333/3335 fail
 ```
 
 If 443 also fails, the issue is likely DNS-level filtering — see the
@@ -334,7 +334,7 @@ eligible automatically with no further action.
 ## Verifying a miner is producing blocks
 
 Pool stats: every accepted share appears in the
-[https://pool.iriumlabs.org/stats](https://pool.iriumlabs.org/stats)
+[https://pool.irium.org/stats](https://pool.irium.org/stats)
 counters within ~30 seconds. Confirmed blocks land in the `blocks_found`
 field.
 
@@ -362,7 +362,7 @@ target block time).
 | Miner connects but submits zero shares | Worker name missing or wrong format | Use `<IRM_ADDRESS>.<worker>` exactly |
 | `stratum+tcp` connect refused on 3333 | ISP block | Switch to port 443 |
 | Many `rejected_low_difficulty` shares | Hardware below baseline diff | Use port 3335 (lower baseline) instead of 3333 |
-| Many `rejected_stale` shares | High network latency or miner clock skew | Sync system clock (NTP); check round-trip latency to `pool.iriumlabs.org` |
+| Many `rejected_stale` shares | High network latency or miner clock skew | Sync system clock (NTP); check round-trip latency to `pool.irium.org` |
 | Block found but no reward credit yet | Coinbase maturity (100 blocks ≈ 3 hours) | Wait; or `irium-wallet history <address>` to see unmatured coinbase |
 | Pre-fork: standard SHA-256d miner finds shares but no blocks | Header hashing differs pre-Fix-2a | Wait for block 22,888; or use bundled `irium-miner` until then |
 

--- a/docs/github-issues-to-open.md
+++ b/docs/github-issues-to-open.md
@@ -52,10 +52,10 @@ Docker images for iriumd and irium-miner are built in the GitHub Actions release
 
 ## Mining and Pool Infrastructure
 
-**Title:** List community mining pools on iriumlabs.org once operators apply
+**Title:** List community mining pools on irium.org once operators apply
 **Labels:** community
 **Body:**
-The pool operator guide (docs/POOL-OPERATOR.md) and recruitment outreach content are in place. Once community pool operators apply via Telegram or GitHub Issues, add verified pools to the mining page at iriumlabs.org/docs/mining/. Minimum requirements: public Stratum endpoint, at least one valid block submitted to mainnet.
+The pool operator guide (docs/POOL-OPERATOR.md) and recruitment outreach content are in place. Once community pool operators apply via Telegram or GitHub Issues, add verified pools to the mining page at irium.org/docs/mining/. Minimum requirements: public Stratum endpoint, at least one valid block submitted to mainnet.
 
 ---
 

--- a/docs/outreach/pool-recruitment-bitcointalk.md
+++ b/docs/outreach/pool-recruitment-bitcointalk.md
@@ -70,7 +70,7 @@ Pool operator guide: https://github.com/iriumlabs/irium/blob/main/docs/POOL-OPER
 
 **We Are Seeking Community Pool Operators**
 
-If you operate a SHA-256d pool or have the infrastructure to run one, we want to list your pool on iriumlabs.org.
+If you operate a SHA-256d pool or have the infrastructure to run one, we want to list your pool on irium.org.
 
 Requirements:
 - Public Stratum endpoint, reachable and responding
@@ -87,7 +87,7 @@ To register interest:
 **Links**
 
 - GitHub: https://github.com/iriumlabs/irium
-- Website: https://www.iriumlabs.org
+- Website: https://www.irium.org
 - Telegram: https://t.me/iriumlabs
 - Pool operator guide: https://github.com/iriumlabs/irium/blob/main/docs/POOL-OPERATOR.md
 - Merged mining guide: https://github.com/iriumlabs/irium/blob/main/docs/MERGED-MINING.md

--- a/docs/outreach/pool-recruitment-telegram.md
+++ b/docs/outreach/pool-recruitment-telegram.md
@@ -19,7 +19,7 @@ We are building the pool infrastructure now and looking for operators who want t
 — Ready-to-deploy Stratum server in the repo: `pool/irium-stratum` (handles both standard and merged mining automatically)
 — Complete pool operator documentation: https://github.com/iriumlabs/irium/blob/main/docs/POOL-OPERATOR.md
 — Merged mining technical guide: https://github.com/iriumlabs/irium/blob/main/docs/MERGED-MINING.md
-— Official listing on iriumlabs.org once your pool is verified
+— Official listing on irium.org once your pool is verified
 
 **Block reward:** 50 IRM per block. First halving at block 210,000. Chain is at height 20,299 — still early.
 

--- a/docs/outreach/seed-node-recruitment-bitcointalk.md
+++ b/docs/outreach/seed-node-recruitment-bitcointalk.md
@@ -59,8 +59,8 @@ Only verified community nodes with confirmed uptime are added.
 
 **Links**
 - GitHub: https://github.com/iriumlabs/irium
-- Website: https://www.iriumlabs.org
-- Network status: https://www.iriumlabs.org/status/
+- Website: https://www.irium.org
+- Network status: https://www.irium.org/status/
 - Seed node guide: https://github.com/iriumlabs/irium/blob/main/docs/SEED-NODE.md
 - Telegram: https://t.me/iriumlabs
 

--- a/mine-cpu-mac.sh
+++ b/mine-cpu-mac.sh
@@ -9,7 +9,7 @@
 # The bundled irium-miner is SOLO-mode only, so this connects to a
 # local iriumd at http://127.0.0.1:38300 — start iriumd yourself or
 # run the Irium Core desktop app first. For pool CPU mining install
-# cpuminer-opt and point it at stratum+tcp://pool.iriumlabs.org:3335.
+# cpuminer-opt and point it at stratum+tcp://pool.irium.org:3335.
 # Auto-restarts on crash with a 5s cool-down. Ctrl+C to stop.
 #
 # If macOS blocks the script: run

--- a/mine-cpu.bat
+++ b/mine-cpu.bat
@@ -15,7 +15,7 @@ REM The bundled irium-miner is a SOLO miner - it talks to a local
 REM iriumd instance (default http://127.0.0.1:38300). Start the
 REM Irium Core desktop app first OR run iriumd yourself before
 REM launching this script. For pool CPU mining install cpuminer-opt
-REM separately and point it at stratum+tcp://pool.iriumlabs.org:3335.
+REM separately and point it at stratum+tcp://pool.irium.org:3335.
 REM Auto-restarts on crash with a 5-second cool-down.
 REM ---------------------------------------------------------------
 

--- a/mine-gpu.bat
+++ b/mine-gpu.bat
@@ -10,14 +10,14 @@ REM Drop this file alongside irium-miner-gpu.exe and double-click.
 REM First run: asks for your Irium wallet address and saves it to
 REM mine-config.txt next to the binary. Subsequent runs read the
 REM address from there. Connects to the official Irium pool at
-REM pool.iriumlabs.org:3335 (CPU/GPU profile). Auto-restarts on
+REM pool.irium.org:3335 (CPU/GPU profile). Auto-restarts on
 REM crash with a 5-second cool-down. Close the window to stop.
 REM ---------------------------------------------------------------
 
 set "SCRIPT_DIR=%~dp0"
 set "MINER_EXE=%SCRIPT_DIR%irium-miner-gpu.exe"
 set "CONFIG_FILE=%SCRIPT_DIR%mine-config.txt"
-set "POOL_URL=stratum+tcp://pool.iriumlabs.org:3335"
+set "POOL_URL=stratum+tcp://pool.irium.org:3335"
 
 if not exist "%MINER_EXE%" (
     color 0C
@@ -48,7 +48,7 @@ if not defined WALLET (
     echo  ----------------------------------------------------------------
     echo.
     echo  You will mine SHA-256d shares against the Irium official pool
-    echo  ^(pool.iriumlabs.org^). When one of your shares meets the
+    echo  ^(pool.irium.org^). When one of your shares meets the
     echo  network target, the FULL block reward goes to YOUR address.
     echo  There is no pool fee.
     echo.

--- a/mine-gpu.sh
+++ b/mine-gpu.sh
@@ -4,14 +4,14 @@
 # Drop next to irium-miner-gpu and run: ./mine-gpu.sh
 # First run prompts for your Irium wallet address and saves it to
 # mine-config.txt. Subsequent runs read from there. Connects to the
-# official Irium pool at pool.iriumlabs.org:3335 in SOLO payout mode.
+# official Irium pool at pool.irium.org:3335 in SOLO payout mode.
 # Auto-restarts on crash with a 5s cool-down. Ctrl+C to stop.
 
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MINER_BIN="${SCRIPT_DIR}/irium-miner-gpu"
 CONFIG_FILE="${SCRIPT_DIR}/mine-config.txt"
-POOL_URL="stratum+tcp://pool.iriumlabs.org:3335"
+POOL_URL="stratum+tcp://pool.irium.org:3335"
 
 if [ ! -x "${MINER_BIN}" ]; then
     if [ -f "${MINER_BIN}" ]; then
@@ -39,7 +39,7 @@ if [ -z "${WALLET}" ]; then
     echo "----------------------------------------------------------------"
     echo
     echo "You will mine SHA-256d shares against the Irium official pool"
-    echo "(pool.iriumlabs.org). When one of your shares meets the network"
+    echo "(pool.irium.org). When one of your shares meets the network"
     echo "target, the FULL block reward goes to YOUR Irium address."
     echo "There is no pool fee."
     echo


### PR DESCRIPTION
Migrates user-facing pool/website URLs from **iriumlabs.org** to **irium.org** as part of the domain migration.

**Additive — nothing breaks:** the old iriumlabs.org endpoints remain fully served (additive nginx server blocks + unchanged DNS/certs), so existing miners and links keep working. This PR only updates the canonical URLs shown in docs.

**Scope (14 files, URL swap only, no code):** README, QUICKSTART, docs/MINING, GPU-MINER, MINING-QUICKSTART, mine-* scripts, docs/outreach/*, LISTING-APPLICATION, github-issues-to-open.

**Deliberately excluded:** `info@iriumlabs.org` email (deferred pending MX for irium.org), bootstrap trust identities (signature-verification infra), and the desktop app / irium-core (separate release cycle).